### PR TITLE
test: add unit tests for network and uniswap modules

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,6 +1,9 @@
 mod network;
 mod uniswap;
 
+#[cfg(test)]
+mod tests;
+
 use std::env;
 
 use alloy::primitives::U256;

--- a/agent/src/tests/mod.rs
+++ b/agent/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod network;
+mod uniswap;

--- a/agent/src/tests/network.rs
+++ b/agent/src/tests/network.rs
@@ -1,0 +1,87 @@
+use crate::network::{AgentMessage, TOPIC};
+
+#[test]
+fn topic_constant() {
+    assert_eq!(TOPIC, "v4-swap-agents");
+}
+
+#[test]
+fn chat_message_roundtrip() {
+    let msg = AgentMessage::Chat {
+        content: "hello".into(),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::Chat { content } => assert_eq!(content, "hello"),
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn swap_executed_roundtrip() {
+    let msg = AgentMessage::SwapExecuted {
+        agent: "peer1".into(),
+        direction: "A→B".into(),
+        amount: "100".into(),
+        tx_hash: "0xabc".into(),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::SwapExecuted {
+            agent,
+            direction,
+            amount,
+            tx_hash,
+        } => {
+            assert_eq!(agent, "peer1");
+            assert_eq!(direction, "A→B");
+            assert_eq!(amount, "100");
+            assert_eq!(tx_hash, "0xabc");
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn swap_request_roundtrip() {
+    let msg = AgentMessage::SwapRequest {
+        direction: "B→A".into(),
+        amount: "50".into(),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::SwapRequest { direction, amount } => {
+            assert_eq!(direction, "B→A");
+            assert_eq!(amount, "50");
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn serialized_json_has_type_tag() {
+    let chat = serde_json::to_value(&AgentMessage::Chat {
+        content: "hi".into(),
+    })
+    .unwrap();
+    assert_eq!(chat["type"], "Chat");
+
+    let exec = serde_json::to_value(&AgentMessage::SwapExecuted {
+        agent: "a".into(),
+        direction: "d".into(),
+        amount: "1".into(),
+        tx_hash: "0x".into(),
+    })
+    .unwrap();
+    assert_eq!(exec["type"], "SwapExecuted");
+
+    let req = serde_json::to_value(&AgentMessage::SwapRequest {
+        direction: "d".into(),
+        amount: "1".into(),
+    })
+    .unwrap();
+    assert_eq!(req["type"], "SwapRequest");
+}

--- a/agent/src/tests/uniswap.rs
+++ b/agent/src/tests/uniswap.rs
@@ -1,0 +1,60 @@
+use alloy::primitives::{address, Signed, Uint};
+
+use crate::uniswap::{SwapClient, HOOK, SWAP_ROUTER, TKNA, TKNB};
+
+#[test]
+fn contract_address_tkna() {
+    assert_eq!(TKNA, address!("7546360e0011Bb0B52ce10E21eF0E9341453fE71"));
+}
+
+#[test]
+fn contract_address_tknb() {
+    assert_eq!(TKNB, address!("F6d91478e66CE8161e15Da103003F3BA6d2bab80"));
+}
+
+#[test]
+fn contract_address_swap_router() {
+    assert_eq!(
+        SWAP_ROUTER,
+        address!("f13D190e9117920c703d79B5F33732e10049b115")
+    );
+}
+
+#[test]
+fn contract_address_hook() {
+    assert_eq!(HOOK, address!("5D4505AA950a73379B8E9f1116976783Ba8340C0"));
+}
+
+#[test]
+fn swap_client_new_does_not_panic() {
+    let _client = SwapClient::new("http://localhost:8545".into(), "0xdead".into());
+}
+
+#[test]
+fn pool_key_fee() {
+    let key = SwapClient::pool_key();
+    assert_eq!(key.fee, Uint::<24, 1>::from(3000u16));
+}
+
+#[test]
+fn pool_key_tick_spacing() {
+    let key = SwapClient::pool_key();
+    assert_eq!(key.tickSpacing, Signed::<24, 1>::try_from(60).unwrap());
+}
+
+#[test]
+fn pool_key_token_ordering() {
+    let key = SwapClient::pool_key();
+    assert!(
+        key.currency0 < key.currency1,
+        "currency0 must be < currency1"
+    );
+    assert_eq!(key.currency0, TKNA);
+    assert_eq!(key.currency1, TKNB);
+}
+
+#[test]
+fn pool_key_hook_address() {
+    let key = SwapClient::pool_key();
+    assert_eq!(key.hooks, HOOK);
+}

--- a/agent/src/uniswap.rs
+++ b/agent/src/uniswap.rs
@@ -63,7 +63,7 @@ impl SwapClient {
         }
     }
 
-    fn pool_key() -> PoolKey {
+    pub(crate) fn pool_key() -> PoolKey {
         PoolKey {
             currency0: TKNA,
             currency1: TKNB,


### PR DESCRIPTION
## Summary
- Add 14 unit tests in dedicated `agent/src/tests/` directory covering network message serialization and uniswap contract/pool configuration
- Tests require no network or RPC access — all run offline
- Make `pool_key()` `pub(crate)` to allow test verification of fee, tick spacing, token ordering, and hook address

## Test plan
- [x] `cargo test` — all 14 tests pass
- [ ] Verify no regressions in existing functionality

## Summary by Sourcery

Add offline unit test coverage for network messaging and Uniswap configuration, adjusting visibility to support verification of pool parameters.

Enhancements:
- Expose the Uniswap pool_key helper as pub(crate) to allow internal verification of pool configuration.

Tests:
- Add unit tests validating AgentMessage topic, serialization roundtrips, and JSON type tags for all network message variants.
- Add unit tests verifying Uniswap contract addresses, SwapClient construction, and pool configuration parameters including fee, tick spacing, token ordering, and hook address.