### PR TITLE
feat: add PeerId <-> EOA identity binding via EIP-191 attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ libp2p-v4-swap-agents/
 │       ├── main.rs          # Event loop, CLI commands
 │       ├── network.rs       # gossipsub + mDNS behaviour
 │       ├── uniswap.rs       # On-chain swap client (Alloy)
+│       ├── identity.rs      # PeerId <-> EOA identity binding (EIP-191)
 │       └── tests/           # Unit tests
 └── README.md
 ```
@@ -72,6 +73,15 @@ An upgraded hook that fixes V1's agent tracking bug and adds dynamic fee rebates
 - **hookData agent tracking** - Decodes the real agent EOA from hookData (V1 incorrectly tracked the router address)
 - **Dynamic fee rebates** - Frequent agents (5+ swaps) pay 0.20% instead of the 0.30% base fee
 - **DYNAMIC_FEE_FLAG pool** - Uses Uniswap V4's fee override mechanism via `_beforeSwap`
+
+### PeerId <-> EOA Identity Binding
+
+Agents cryptographically prove they control an Ethereum address by signing their libp2p PeerId with their ETH private key (EIP-191). On peer connection, the signed attestation is broadcast over gossipsub. Receiving peers verify the signature, linking the P2P identity to an on-chain address.
+
+- **EIP-191 signing** - Signs `"libp2p-v4-swap-agents:identity:{peer_id}"` with the agent's Ethereum key
+- **Automatic exchange** - Attestation is published on every new peer connection
+- **Signature verification** - Peers recover the signer address and reject mismatches
+- **Peer registry** - Stores all verified PeerId -> EOA bindings locally
 
 ## Deployed Contracts (Sepolia)
 
@@ -137,6 +147,8 @@ cd agent && cargo run -- /ip4/127.0.0.1/tcp/<PORT>
 | `swap-v2-b <amount>` | Swap TKNB -> TKNA (V2 pool, fee rebates) |
 | `status` | Query V1 on-chain swap counts |
 | `status-v2` | Query V2 swap counts + your fee tier |
+| `who` | Show your PeerId and linked EOA |
+| `peers` | List all verified peer identities |
 | `dial <multiaddr>` | Connect to a peer manually |
 | `help` | Show available commands |
 | `<text>` | Send chat message to peers |
@@ -166,7 +178,8 @@ cd agent && cargo run
 ```
 === libp2p Uniswap V4 Swap Agent ===
 Peer ID: 12D3KooWExamplePeerIdA...
-Topic: v4-swap-agents
+EOA:     0x817cA93300590bF6AA0DFbFa592b055F7eb20090
+Topic:   v4-swap-agents
 Type 'help' for available commands.
 
 Listening on /ip4/127.0.0.1/tcp/54321
@@ -181,17 +194,19 @@ Use the TCP address from Agent A's output:
 cd agent && cargo run -- /ip4/127.0.0.1/tcp/54321
 ```
 
-Both terminals will show discovery and connection:
+Both terminals will show discovery, connection, and identity verification:
 
 ```
 # Agent B
 Dialing /ip4/127.0.0.1/tcp/54321...
 mDNS discovered peer: 12D3KooWExamplePeerIdA...
 Connected to peer: 12D3KooWExamplePeerIdA...
+[IDENTITY] Verified: 12D3KooWExamplePeerIdA... -> 0x817c...
 
 # Agent A
 mDNS discovered peer: 12D3KooWExamplePeerIdB...
 Connected to peer: 12D3KooWExamplePeerIdB...
+[IDENTITY] Verified: 12D3KooWExamplePeerIdB... -> 0xf39F...
 ```
 
 ### Step 3 — Chat
@@ -319,7 +334,7 @@ cp .env.example .env
 - [x] Integration demo
 - [x] Screencast (2-4 min walkthrough)
 - [x] AgentCounterV2 — dynamic fee rebates + hookData agent tracking (6 tests)
-- [ ] PeerId <-> EOA identity binding
+- [x] PeerId <-> EOA identity binding (EIP-191 attestation, 6 tests)
 - [ ] Swap intent gossip
 
 ## License

--- a/agent/src/identity.rs
+++ b/agent/src/identity.rs
@@ -1,0 +1,86 @@
+use alloy::hex;
+use alloy::primitives::Address;
+use alloy::signers::local::PrivateKeySigner;
+use alloy::signers::Signer;
+use anyhow::Result;
+use std::collections::HashMap;
+
+/// Message prefix for identity attestation signing.
+/// Format: "libp2p-v4-swap-agents:identity:{peer_id}"
+const ATTESTATION_PREFIX: &str = "libp2p-v4-swap-agents:identity:";
+
+/// Cryptographic binding between a libp2p PeerId and an Ethereum EOA.
+/// The agent signs a message containing their PeerId with their Ethereum private key,
+/// proving they control both identities.
+#[derive(Debug, Clone)]
+pub struct IdentityBinding {
+    pub peer_id: String,
+    pub eoa: Address,
+    /// Hex-encoded 65-byte EIP-191 signature (r || s || v)
+    pub signature: String,
+}
+
+impl IdentityBinding {
+    /// Create a signed attestation linking a PeerId to an EOA.
+    /// Uses EIP-191 personal_sign to sign the message "libp2p-v4-swap-agents:identity:{peer_id}".
+    pub async fn create(private_key: &str, peer_id: &str) -> Result<Self> {
+        let signer: PrivateKeySigner = private_key.parse()?;
+        let eoa = signer.address();
+        let message = format!("{ATTESTATION_PREFIX}{peer_id}");
+        let sig = signer.sign_message(message.as_bytes()).await?;
+        let sig_hex = hex::encode(sig.as_bytes());
+
+        Ok(Self {
+            peer_id: peer_id.to_string(),
+            eoa,
+            signature: sig_hex,
+        })
+    }
+
+    /// Construct an IdentityBinding from its parts (used when deserializing from a peer message).
+    pub fn from_parts(peer_id: String, eoa: Address, signature: String) -> Self {
+        Self {
+            peer_id,
+            eoa,
+            signature,
+        }
+    }
+
+    /// Verify that the signature was produced by the claimed EOA.
+    /// Recovers the signer address from the EIP-191 signature and compares with the claimed EOA.
+    pub fn verify(&self) -> Result<bool> {
+        let message = format!("{ATTESTATION_PREFIX}{}", self.peer_id);
+        let sig_bytes = hex::decode(&self.signature)?;
+        let sig = alloy::primitives::PrimitiveSignature::try_from(sig_bytes.as_slice())?;
+        let recovered = sig.recover_address_from_msg(message.as_bytes())?;
+        Ok(recovered == self.eoa)
+    }
+}
+
+/// Registry mapping PeerIds to verified IdentityBindings.
+pub struct PeerRegistry {
+    bindings: HashMap<String, IdentityBinding>,
+}
+
+impl PeerRegistry {
+    pub fn new() -> Self {
+        Self {
+            bindings: HashMap::new(),
+        }
+    }
+
+    /// Register a verified identity binding for a peer.
+    pub fn register(&mut self, binding: IdentityBinding) {
+        self.bindings.insert(binding.peer_id.clone(), binding);
+    }
+
+    /// Look up the identity binding for a peer.
+    pub fn get(&self, peer_id: &str) -> Option<&IdentityBinding> {
+        self.bindings.get(peer_id)
+    }
+
+    /// Get all registered identity bindings.
+    pub fn all(&self) -> &HashMap<String, IdentityBinding> {
+        &self.bindings
+    }
+}

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,3 +1,4 @@
+mod identity;
 mod network;
 mod uniswap;
 
@@ -6,7 +7,7 @@ mod tests;
 
 use std::env;
 
-use alloy::primitives::U256;
+use alloy::primitives::{Address, U256};
 use anyhow::Result;
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
@@ -14,6 +15,7 @@ use libp2p::{gossipsub, mdns, Multiaddr};
 use tokio::io::{self, AsyncBufReadExt};
 use tracing_subscriber::EnvFilter;
 
+use identity::{IdentityBinding, PeerRegistry};
 use network::{AgentBehaviourEvent, AgentMessage, TOPIC};
 use uniswap::SwapClient;
 
@@ -28,7 +30,7 @@ async fn main() -> Result<()> {
     let rpc_url = env::var("SEPOLIA_RPC_URL").expect("SEPOLIA_RPC_URL must be set");
     let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
 
-    let swap_client = SwapClient::new(rpc_url, private_key);
+    let swap_client = SwapClient::new(rpc_url, private_key.clone());
 
     let mut swarm = network::build_swarm()?;
 
@@ -39,10 +41,25 @@ async fn main() -> Result<()> {
     swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse::<Multiaddr>()?)?;
     swarm.listen_on("/ip4/0.0.0.0/udp/0/quic-v1".parse::<Multiaddr>()?)?;
 
+    // Create identity attestation: sign PeerId with Ethereum private key
+    let peer_id_str = swarm.local_peer_id().to_string();
+    let own_binding = IdentityBinding::create(&private_key, &peer_id_str).await?;
+
     println!("=== libp2p Uniswap V4 Swap Agent ===");
-    println!("Peer ID: {}", swarm.local_peer_id());
-    println!("Topic: {TOPIC}");
+    println!("Peer ID: {}", peer_id_str);
+    println!("EOA:     {}", own_binding.eoa);
+    println!("Topic:   {TOPIC}");
     println!("Type 'help' for available commands.\n");
+
+    // Pre-build the attestation message to publish on each new connection
+    let attestation_msg = AgentMessage::IdentityAttestation {
+        peer_id: own_binding.peer_id.clone(),
+        eoa: format!("{}", own_binding.eoa),
+        signature: own_binding.signature.clone(),
+    };
+
+    let mut peer_registry = PeerRegistry::new();
+    peer_registry.register(own_binding);
 
     // Dial a remote peer if provided as CLI argument
     if let Some(addr) = env::args().nth(1) {
@@ -61,11 +78,11 @@ async fn main() -> Result<()> {
         tokio::select! {
             line = stdin.next_line() => {
                 if let Ok(Some(line)) = line {
-                    handle_input(&line, &topic, &mut swarm, &swap_client).await;
+                    handle_input(&line, &topic, &mut swarm, &swap_client, &peer_registry).await;
                 }
             }
             event = swarm.select_next_some() => {
-                handle_swarm_event(event, &mut swarm);
+                handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry);
             }
         }
     }
@@ -76,6 +93,7 @@ async fn handle_input(
     topic: &gossipsub::IdentTopic,
     swarm: &mut libp2p::Swarm<network::AgentBehaviour>,
     swap_client: &SwapClient,
+    peer_registry: &PeerRegistry,
 ) {
     let trimmed = line.trim();
     if trimmed.is_empty() {
@@ -93,6 +111,8 @@ async fn handle_input(
             println!("  swap-v2-b <amount>  - Swap TKNB -> TKNA (V2 pool, fee rebates)");
             println!("  status              - Query V1 on-chain swap counts");
             println!("  status-v2           - Query V2 swap counts + your fee tier");
+            println!("  who                 - Show your PeerId and EOA");
+            println!("  peers               - List all verified peer identities");
             println!("  help                - Show this message");
             println!("  <text>              - Send chat message to peers");
         }
@@ -167,6 +187,26 @@ async fn handle_input(
             Ok(counts) => println!("{counts}"),
             Err(e) => println!("Failed to query V2 counts: {e}"),
         },
+        // Show own PeerId <-> EOA identity binding
+        "who" => {
+            let my_peer_id = swarm.local_peer_id().to_string();
+            if let Some(binding) = peer_registry.get(&my_peer_id) {
+                println!("PeerId: {}", binding.peer_id);
+                println!("EOA:    {}", binding.eoa);
+            }
+        }
+        // List all verified peer identity bindings
+        "peers" => {
+            let bindings = peer_registry.all();
+            if bindings.is_empty() {
+                println!("No verified peers.");
+            } else {
+                println!("Verified peers ({}):", bindings.len());
+                for binding in bindings.values() {
+                    println!("  {} -> {}", binding.peer_id, binding.eoa);
+                }
+            }
+        }
         _ => {
             let msg = AgentMessage::Chat {
                 content: trimmed.to_string(),
@@ -200,6 +240,9 @@ fn publish_message(
 fn handle_swarm_event(
     event: SwarmEvent<AgentBehaviourEvent>,
     swarm: &mut libp2p::Swarm<network::AgentBehaviour>,
+    topic: &gossipsub::IdentTopic,
+    attestation_msg: &AgentMessage,
+    peer_registry: &mut PeerRegistry,
 ) {
     match event {
         SwarmEvent::Behaviour(AgentBehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
@@ -248,6 +291,46 @@ fn handle_swarm_event(
                             "[REQUEST] Peer {peer_id} requests swap: {amount} ({direction})"
                         );
                     }
+                    // Verify incoming identity attestation and register if valid
+                    AgentMessage::IdentityAttestation {
+                        peer_id: attested_peer_id,
+                        eoa,
+                        signature,
+                    } => {
+                        let eoa_addr: Address = match eoa.parse() {
+                            Ok(a) => a,
+                            Err(_) => {
+                                println!("[IDENTITY] Invalid EOA from {peer_id}: {eoa}");
+                                return;
+                            }
+                        };
+                        let binding = IdentityBinding::from_parts(
+                            attested_peer_id.clone(),
+                            eoa_addr,
+                            signature,
+                        );
+                        match binding.verify() {
+                            Ok(true) => {
+                                println!(
+                                    "[IDENTITY] Verified: {} -> {}",
+                                    attested_peer_id, eoa_addr
+                                );
+                                peer_registry.register(binding);
+                            }
+                            Ok(false) => {
+                                println!(
+                                    "[IDENTITY] REJECTED (signature mismatch): {} claimed {}",
+                                    attested_peer_id, eoa_addr
+                                );
+                            }
+                            Err(e) => {
+                                println!(
+                                    "[IDENTITY] Verification error for {}: {e}",
+                                    attested_peer_id
+                                );
+                            }
+                        }
+                    }
                 }
             } else {
                 // Fallback: treat as plain text
@@ -264,6 +347,8 @@ fn handle_swarm_event(
                 .behaviour_mut()
                 .gossipsub
                 .add_explicit_peer(&peer_id);
+            // Publish our identity attestation so the new peer can verify our EOA
+            publish_message(swarm, topic, attestation_msg);
         }
         SwarmEvent::ConnectionClosed { peer_id, .. } => {
             println!("Disconnected from peer: {peer_id}");

--- a/agent/src/network.rs
+++ b/agent/src/network.rs
@@ -31,6 +31,12 @@ pub enum AgentMessage {
         direction: String,
         amount: String,
     },
+    /// PeerId <-> EOA identity attestation (EIP-191 signed proof of Ethereum address ownership)
+    IdentityAttestation {
+        peer_id: String,
+        eoa: String,
+        signature: String,
+    },
 }
 
 pub fn build_swarm() -> Result<Swarm<AgentBehaviour>> {

--- a/agent/src/tests/identity.rs
+++ b/agent/src/tests/identity.rs
@@ -1,0 +1,132 @@
+use alloy::primitives::address;
+
+use crate::identity::{IdentityBinding, PeerRegistry};
+
+// Test private key (Hardhat account #0 — never use with real funds)
+const TEST_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+// Corresponding EOA for the test key
+const TEST_EOA: alloy::primitives::Address =
+    address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+#[tokio::test]
+async fn attestation_roundtrip() {
+    let peer_id = "12D3KooWTestPeerId123456789";
+    let binding = IdentityBinding::create(TEST_KEY, peer_id)
+        .await
+        .expect("create attestation");
+
+    assert_eq!(binding.peer_id, peer_id);
+    assert_eq!(binding.eoa, TEST_EOA);
+    assert!(!binding.signature.is_empty());
+
+    // Verify the signature
+    assert!(binding.verify().expect("verify"), "signature should be valid");
+}
+
+#[tokio::test]
+async fn attestation_from_parts_verifies() {
+    let peer_id = "12D3KooWAnotherPeer";
+    let binding = IdentityBinding::create(TEST_KEY, peer_id)
+        .await
+        .expect("create attestation");
+
+    // Reconstruct from parts (as if deserialized from a gossipsub message)
+    let reconstructed = IdentityBinding::from_parts(
+        binding.peer_id.clone(),
+        binding.eoa,
+        binding.signature.clone(),
+    );
+
+    assert!(
+        reconstructed.verify().expect("verify"),
+        "reconstructed binding should verify"
+    );
+}
+
+#[tokio::test]
+async fn tampered_signature_rejected() {
+    let peer_id = "12D3KooWTamperTest";
+    let binding = IdentityBinding::create(TEST_KEY, peer_id)
+        .await
+        .expect("create attestation");
+
+    // Tamper with the signature by flipping a byte
+    let mut tampered_sig = alloy::hex::decode(&binding.signature).unwrap();
+    tampered_sig[10] ^= 0xFF;
+    let tampered_hex = alloy::hex::encode(&tampered_sig);
+
+    let tampered = IdentityBinding::from_parts(peer_id.to_string(), TEST_EOA, tampered_hex);
+
+    // Verification should either fail or return false
+    match tampered.verify() {
+        Ok(valid) => assert!(!valid, "tampered signature should not verify"),
+        Err(_) => {} // Signature parsing error is also acceptable
+    }
+}
+
+#[tokio::test]
+async fn wrong_peer_id_rejected() {
+    let peer_id = "12D3KooWOriginalPeer";
+    let binding = IdentityBinding::create(TEST_KEY, peer_id)
+        .await
+        .expect("create attestation");
+
+    // Use the valid signature but claim a different PeerId
+    let wrong_peer = IdentityBinding::from_parts(
+        "12D3KooWDifferentPeer".to_string(),
+        binding.eoa,
+        binding.signature,
+    );
+
+    match wrong_peer.verify() {
+        Ok(valid) => assert!(!valid, "wrong peer_id should not verify"),
+        Err(_) => {} // Recovery error is also acceptable
+    }
+}
+
+#[tokio::test]
+async fn peer_registry_operations() {
+    let mut registry = PeerRegistry::new();
+    assert!(registry.all().is_empty());
+
+    let binding = IdentityBinding::create(TEST_KEY, "12D3KooWPeer1")
+        .await
+        .expect("create attestation");
+
+    registry.register(binding.clone());
+
+    assert_eq!(registry.all().len(), 1);
+    let retrieved = registry.get("12D3KooWPeer1").expect("peer should exist");
+    assert_eq!(retrieved.eoa, TEST_EOA);
+    assert_eq!(retrieved.peer_id, "12D3KooWPeer1");
+
+    // Non-existent peer
+    assert!(registry.get("12D3KooWNonExistent").is_none());
+}
+
+#[test]
+fn identity_attestation_message_serialization() {
+    use crate::network::AgentMessage;
+
+    let msg = AgentMessage::IdentityAttestation {
+        peer_id: "12D3KooWTestPeer".to_string(),
+        eoa: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266".to_string(),
+        signature: "deadbeef".to_string(),
+    };
+
+    let json = serde_json::to_string(&msg).expect("serialize");
+    let deserialized: AgentMessage = serde_json::from_str(&json).expect("deserialize");
+
+    match deserialized {
+        AgentMessage::IdentityAttestation {
+            peer_id,
+            eoa,
+            signature,
+        } => {
+            assert_eq!(peer_id, "12D3KooWTestPeer");
+            assert_eq!(eoa, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+            assert_eq!(signature, "deadbeef");
+        }
+        _ => panic!("expected IdentityAttestation variant"),
+    }
+}

--- a/agent/src/tests/mod.rs
+++ b/agent/src/tests/mod.rs
@@ -1,2 +1,3 @@
+mod identity;
 mod network;
 mod uniswap;

--- a/agent/src/tests/uniswap.rs
+++ b/agent/src/tests/uniswap.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{address, Address, Signed, Uint};
+use alloy::primitives::{address, Signed, Uint};
 
 use crate::uniswap::{SwapClient, DYNAMIC_FEE_FLAG, HOOK, HOOK_V2, SWAP_ROUTER, TKNA, TKNB};
 


### PR DESCRIPTION
- New identity.rs module: IdentityBinding (create/verify) + PeerRegistry
- Agents sign their PeerId with ETH private key on startup
- Attestation auto-published over gossipsub on peer connection
- Peers verify EIP-191 signature and store in registry
- New CLI commands: who (own identity), peers (all verified bindings)
- Added IdentityAttestation variant to AgentMessage
- 6 new identity tests (25 total), all passing

## Summary by Sourcery

Add cryptographic binding between libp2p PeerId and Ethereum EOA using EIP-191 attestations and integrate identity exchange into the agent protocol and CLI.

New Features:
- Introduce an IdentityBinding abstraction and PeerRegistry to create, verify, and store PeerId-to-EOA attestations.
- Broadcast and handle IdentityAttestation messages over gossipsub so peers can automatically exchange and verify identities on connection.
- Expose new CLI commands to display the local PeerId/EOA binding and list all verified peer identities.

Enhancements:
- Extend agent startup to derive and display the local EOA alongside the PeerId and prepare an identity attestation for reuse.
- Document the identity binding flow, CLI commands, and demo output in the README, and mark the identity binding milestone as completed.

Tests:
- Add identity module tests covering attestation creation/verification, tampering and mismatch scenarios, peer registry behavior, and IdentityAttestation message serialization.