### PR TITLE
feat: add simulation mode

### DIFF
--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -1,0 +1,15 @@
+use clap::Parser;
+
+/// libp2p Uniswap V4 Swap Agent
+#[derive(Parser, Debug)]
+#[command(name = "libp2p-swap-agent")]
+#[command(about = "P2P agent for coordinating Uniswap V4 swaps")]
+pub struct Cli {
+    /// Run in simulation mode (no on-chain transactions, env vars optional)
+    #[arg(short, long)]
+    pub simulate: bool,
+
+    /// Multiaddr of a remote peer to dial on startup
+    #[arg(value_name = "MULTIADDR")]
+    pub dial: Option<String>,
+}

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,5 +1,7 @@
+mod cli;
 mod identity;
 mod network;
+mod sim;
 mod uniswap;
 
 #[cfg(test)]
@@ -9,14 +11,17 @@ use std::env;
 
 use alloy::primitives::{Address, U256};
 use anyhow::Result;
+use clap::Parser;
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{gossipsub, mdns, Multiaddr};
 use tokio::io::{self, AsyncBufReadExt};
 use tracing_subscriber::EnvFilter;
 
+use cli::Cli;
 use identity::{IdentityBinding, PeerRegistry};
 use network::{AgentBehaviourEvent, AgentMessage, TOPIC};
+use sim::SimulationMode;
 use uniswap::SwapClient;
 
 #[tokio::main]
@@ -27,8 +32,24 @@ async fn main() -> Result<()> {
 
     dotenvy::dotenv().ok();
 
-    let rpc_url = env::var("SEPOLIA_RPC_URL").expect("SEPOLIA_RPC_URL must be set");
-    let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
+    let cli = Cli::parse();
+    let sim_mode = SimulationMode::new(cli.simulate);
+
+    // In simulation mode, env vars are optional — fall back to hardhat defaults
+    let (rpc_url, private_key) = if sim_mode.is_active() {
+        let rpc = env::var("SEPOLIA_RPC_URL")
+            .unwrap_or_else(|_| "http://localhost:8545".to_string());
+        let key = env::var("PRIVATE_KEY").unwrap_or_else(|_| {
+            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string()
+        });
+        (rpc, key)
+    } else {
+        let rpc = env::var("SEPOLIA_RPC_URL")
+            .expect("SEPOLIA_RPC_URL must be set (use --simulate to skip)");
+        let key = env::var("PRIVATE_KEY")
+            .expect("PRIVATE_KEY must be set (use --simulate to skip)");
+        (rpc, key)
+    };
 
     let swap_client = SwapClient::new(rpc_url, private_key.clone());
 
@@ -45,7 +66,13 @@ async fn main() -> Result<()> {
     let peer_id_str = swarm.local_peer_id().to_string();
     let own_binding = IdentityBinding::create(&private_key, &peer_id_str).await?;
 
+    let mode_label = if sim_mode.is_active() {
+        "SIMULATION"
+    } else {
+        "LIVE (Sepolia)"
+    };
     println!("=== libp2p Uniswap V4 Swap Agent ===");
+    println!("Mode:    {mode_label}");
     println!("Peer ID: {}", peer_id_str);
     println!("EOA:     {}", own_binding.eoa);
     println!("Topic:   {TOPIC}");
@@ -62,7 +89,7 @@ async fn main() -> Result<()> {
     peer_registry.register(own_binding);
 
     // Dial a remote peer if provided as CLI argument
-    if let Some(addr) = env::args().nth(1) {
+    if let Some(addr) = cli.dial {
         match addr.parse::<Multiaddr>() {
             Ok(remote) => {
                 swarm.dial(remote.clone())?;
@@ -78,7 +105,7 @@ async fn main() -> Result<()> {
         tokio::select! {
             line = stdin.next_line() => {
                 if let Ok(Some(line)) = line {
-                    handle_input(&line, &topic, &mut swarm, &swap_client, &peer_registry).await;
+                    handle_input(&line, &topic, &mut swarm, &swap_client, &peer_registry, &sim_mode).await;
                 }
             }
             event = swarm.select_next_some() => {
@@ -94,6 +121,7 @@ async fn handle_input(
     swarm: &mut libp2p::Swarm<network::AgentBehaviour>,
     swap_client: &SwapClient,
     peer_registry: &PeerRegistry,
+    sim_mode: &SimulationMode,
 ) {
     let trimmed = line.trim();
     if trimmed.is_empty() {
@@ -111,6 +139,7 @@ async fn handle_input(
             println!("  swap-v2-b <amount>  - Swap TKNB -> TKNA (V2 pool, fee rebates)");
             println!("  status              - Query V1 on-chain swap counts");
             println!("  status-v2           - Query V2 swap counts + your fee tier");
+            println!("  sim on|off          - Toggle simulation mode at runtime");
             println!("  who                 - Show your PeerId and EOA");
             println!("  peers               - List all verified peer identities");
             println!("  help                - Show this message");
@@ -147,35 +176,50 @@ async fn handle_input(
             };
             let version = if is_v2 { "V2" } else { "V1" };
 
-            println!("Executing {version} swap: {amount_str} {direction}...");
+            if sim_mode.is_active() {
+                let peer_id_str = swarm.local_peer_id().to_string();
+                let tx_hash = sim::simulated_tx_hash(&peer_id_str);
+                println!("[SIM] {version} swap: {amount_str} {direction}");
+                println!("[SIM] tx: {tx_hash}");
 
-            let amount = match amount_str.parse::<u64>() {
-                Ok(a) => U256::from(a) * U256::from(10u64.pow(18)),
-                Err(_) => {
-                    println!("Invalid amount: {amount_str}");
-                    return;
-                }
-            };
-
-            let result = if is_v2 {
-                swap_client.execute_swap_v2(amount, zero_for_one).await
+                let msg = AgentMessage::SwapExecuted {
+                    agent: peer_id_str,
+                    direction: direction.to_string(),
+                    amount: amount_str.to_string(),
+                    tx_hash,
+                };
+                publish_message(swarm, topic, &msg);
             } else {
-                swap_client.execute_swap(amount, zero_for_one).await
-            };
+                println!("Executing {version} swap: {amount_str} {direction}...");
 
-            match result {
-                Ok(tx_hash) => {
-                    let msg = AgentMessage::SwapExecuted {
-                        agent: swarm.local_peer_id().to_string(),
-                        direction: direction.to_string(),
-                        amount: amount_str.to_string(),
-                        tx_hash: tx_hash.clone(),
-                    };
-                    publish_message(swarm, topic, &msg);
-                    println!("Swap complete! tx: {tx_hash}");
-                    println!("  https://sepolia.etherscan.io/tx/{tx_hash}");
+                let amount = match amount_str.parse::<u64>() {
+                    Ok(a) => U256::from(a) * U256::from(10u64.pow(18)),
+                    Err(_) => {
+                        println!("Invalid amount: {amount_str}");
+                        return;
+                    }
+                };
+
+                let result = if is_v2 {
+                    swap_client.execute_swap_v2(amount, zero_for_one).await
+                } else {
+                    swap_client.execute_swap(amount, zero_for_one).await
+                };
+
+                match result {
+                    Ok(tx_hash) => {
+                        let msg = AgentMessage::SwapExecuted {
+                            agent: swarm.local_peer_id().to_string(),
+                            direction: direction.to_string(),
+                            amount: amount_str.to_string(),
+                            tx_hash: tx_hash.clone(),
+                        };
+                        publish_message(swarm, topic, &msg);
+                        println!("Swap complete! tx: {tx_hash}");
+                        println!("  https://sepolia.etherscan.io/tx/{tx_hash}");
+                    }
+                    Err(e) => println!("Swap failed: {e}"),
                 }
-                Err(e) => println!("Swap failed: {e}"),
             }
         }
         "status" => match swap_client.get_swap_counts().await {
@@ -196,6 +240,24 @@ async fn handle_input(
             }
         }
         // List all verified peer identity bindings
+        "sim" => {
+            if let Some(arg) = parts.get(1) {
+                match *arg {
+                    "on" => {
+                        sim_mode.set(true);
+                        println!("Simulation mode: ON");
+                    }
+                    "off" => {
+                        sim_mode.set(false);
+                        println!("Simulation mode: OFF");
+                    }
+                    _ => println!("Usage: sim on|off"),
+                }
+            } else {
+                let state = if sim_mode.is_active() { "ON" } else { "OFF" };
+                println!("Simulation mode: {state}");
+            }
+        }
         "peers" => {
             let bindings = peer_registry.all();
             if bindings.is_empty() {

--- a/agent/src/sim.rs
+++ b/agent/src/sim.rs
@@ -1,0 +1,52 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Thread-safe simulation mode flag.
+///
+/// Wraps an `Arc<AtomicBool>` so it can be shared across the async event loop
+/// and toggled at runtime via the `sim on|off` command.
+#[derive(Clone, Debug)]
+pub struct SimulationMode {
+    active: Arc<AtomicBool>,
+}
+
+impl SimulationMode {
+    /// Create a new SimulationMode. Pass `true` to start in simulation mode.
+    pub fn new(active: bool) -> Self {
+        Self {
+            active: Arc::new(AtomicBool::new(active)),
+        }
+    }
+
+    /// Returns `true` if simulation mode is currently active.
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    /// Explicitly set simulation mode on or off.
+    pub fn set(&self, active: bool) {
+        self.active.store(active, Ordering::Relaxed);
+    }
+
+    /// Toggle simulation mode and return the new state.
+    pub fn toggle(&self) -> bool {
+        let prev = self.active.fetch_xor(true, Ordering::Relaxed);
+        !prev
+    }
+}
+
+/// Generate a synthetic transaction hash for simulation mode.
+///
+/// Format: `0xSIM_{last8chars_of_peer_id}_{unix_timestamp_hex}`
+pub fn simulated_tx_hash(peer_id: &str) -> String {
+    let suffix = if peer_id.len() >= 8 {
+        &peer_id[peer_id.len() - 8..]
+    } else {
+        peer_id
+    };
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("0xSIM_{suffix}_{timestamp:x}")
+}

--- a/agent/src/tests/mod.rs
+++ b/agent/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod identity;
 mod network;
 mod uniswap;
+mod sim;

--- a/agent/src/tests/sim.rs
+++ b/agent/src/tests/sim.rs
@@ -1,0 +1,47 @@
+use crate::sim::{simulated_tx_hash, SimulationMode};
+
+#[test]
+fn simulation_mode_default_off() {
+    let mode = SimulationMode::new(false);
+    assert!(!mode.is_active());
+}
+
+#[test]
+fn simulation_mode_toggle() {
+    let mode = SimulationMode::new(false);
+    mode.set(true);
+    assert!(mode.is_active());
+    mode.set(false);
+    assert!(!mode.is_active());
+}
+
+#[test]
+fn simulation_mode_toggle_method() {
+    let mode = SimulationMode::new(false);
+    let new_state = mode.toggle();
+    assert!(new_state);
+    assert!(mode.is_active());
+    let new_state = mode.toggle();
+    assert!(!new_state);
+    assert!(!mode.is_active());
+}
+
+#[test]
+fn simulated_tx_hash_format() {
+    let hash = simulated_tx_hash("12D3KooWTestPeerId123456789");
+    assert!(hash.starts_with("0xSIM_"));
+    let parts: Vec<&str> = hash.split('_').collect();
+    assert_eq!(parts.len(), 3, "expected format: 0xSIM_<suffix>_<hex>");
+    assert_eq!(parts[0], "0xSIM");
+}
+
+#[test]
+fn simulated_tx_hash_contains_peer_suffix() {
+    let peer_id = "12D3KooWTestPeerId123456789";
+    let hash = simulated_tx_hash(peer_id);
+    let expected_suffix = &peer_id[peer_id.len() - 8..];
+    assert!(
+        hash.contains(expected_suffix),
+        "hash {hash} should contain peer suffix {expected_suffix}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `--simulate` CLI flag and `sim on/off` runtime toggle for running agents without on-chain transactions
- Env vars (`PRIVATE_KEY`, `SEPOLIA_RPC_URL`) become optional in sim mode, falling back to hardhat defaults
- Swap commands generate synthetic `0xSIM_...` tx hashes and still publish via gossipsub
- Replace ad-hoc `env::args()` with proper `clap` CLI parsing

## New files
- `agent/src/cli.rs` — clap arg parser (`--simulate`, optional dial multiaddr)
- `agent/src/sim.rs` — `SimulationMode` (Arc<AtomicBool>) + `simulated_tx_hash()`
- `agent/src/tests/sim.rs` — 5 unit tests

## Test plan
- [x] `cargo test` — 30 tests pass (25 existing + 5 new sim tests)
- [x] `cargo run -- --simulate` — starts without `.env`, prints `Mode: SIMULATION`
- [x] `swap 1` in sim mode — prints `[SIM]` output with `0xSIM_...` hash
- [x] `sim off` / `sim on` — toggles mode at runtime
- [x] Two agents in sim mode — gossipsub still exchanges swap messages

## Summary by Sourcery

Introduce a simulation mode for the swap agent, allowing it to run without executing real on-chain transactions while still participating in P2P message exchange.

New Features:
- Add a CLI flag to start the agent in simulation mode and an optional dial address argument.
- Add a runtime `sim on|off` command to toggle simulation mode without restarting the agent.
- Generate synthetic transaction hashes in simulation mode while still publishing swap messages over gossipsub.

Enhancements:
- Replace ad-hoc environment argument handling with a dedicated clap-based CLI parser.
- Make RPC URL and private key environment variables optional when running in simulation mode, with sensible local defaults.
- Display the current operating mode (simulation vs live) in the agent startup banner.

Tests:
- Add unit tests covering SimulationMode behavior and simulated transaction hash formatting.

closes #9 