### PR TITLE
feat: add local Anvil execution mode

### DIFF
--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -9,6 +9,11 @@ pub struct Cli {
     #[arg(short, long)]
     pub simulate: bool,
 
+    /// Execute real swaps against a local Anvil node (requires --simulate).
+    /// Start Anvil first: `anvil --fork-url $SEPOLIA_RPC_URL`
+    #[arg(long, requires = "simulate")]
+    pub local: bool,
+
     /// Multiaddr of a remote peer to dial on startup
     #[arg(value_name = "MULTIADDR")]
     pub dial: Option<String>,

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -33,10 +33,17 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let cli = Cli::parse();
-    let sim_mode = SimulationMode::new(cli.simulate);
+    let sim_mode = SimulationMode::new(cli.simulate, cli.local);
 
-    // In simulation mode, env vars are optional — fall back to hardhat defaults
-    let (rpc_url, private_key) = if sim_mode.is_active() {
+    // Local mode: always use localhost:8545 (Anvil fork)
+    // Simulation mode: env vars optional, fall back to hardhat defaults
+    // Live mode: env vars required
+    let (rpc_url, private_key) = if sim_mode.is_local() {
+        let key = env::var("PRIVATE_KEY").unwrap_or_else(|_| {
+            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string()
+        });
+        ("http://localhost:8545".to_string(), key)
+    } else if sim_mode.is_active() {
         let rpc = env::var("SEPOLIA_RPC_URL")
             .unwrap_or_else(|_| "http://localhost:8545".to_string());
         let key = env::var("PRIVATE_KEY").unwrap_or_else(|_| {
@@ -66,11 +73,7 @@ async fn main() -> Result<()> {
     let peer_id_str = swarm.local_peer_id().to_string();
     let own_binding = IdentityBinding::create(&private_key, &peer_id_str).await?;
 
-    let mode_label = if sim_mode.is_active() {
-        "SIMULATION"
-    } else {
-        "LIVE (Sepolia)"
-    };
+    let mode_label = sim_mode.get().label();
     println!("=== libp2p Uniswap V4 Swap Agent ===");
     println!("Mode:    {mode_label}");
     println!("Peer ID: {}", peer_id_str);
@@ -139,7 +142,7 @@ async fn handle_input(
             println!("  swap-v2-b <amount>  - Swap TKNB -> TKNA (V2 pool, fee rebates)");
             println!("  status              - Query V1 on-chain swap counts");
             println!("  status-v2           - Query V2 swap counts + your fee tier");
-            println!("  sim on|off          - Toggle simulation mode at runtime");
+            println!("  sim on|off|local    - Set execution mode (sim/live/local-anvil)");
             println!("  who                 - Show your PeerId and EOA");
             println!("  peers               - List all verified peer identities");
             println!("  help                - Show this message");
@@ -216,7 +219,9 @@ async fn handle_input(
                         };
                         publish_message(swarm, topic, &msg);
                         println!("Swap complete! tx: {tx_hash}");
-                        println!("  https://sepolia.etherscan.io/tx/{tx_hash}");
+                        if !sim_mode.is_local() {
+                            println!("  https://sepolia.etherscan.io/tx/{tx_hash}");
+                        }
                     }
                     Err(e) => println!("Swap failed: {e}"),
                 }
@@ -249,13 +254,16 @@ async fn handle_input(
                     }
                     "off" => {
                         sim_mode.set(false);
-                        println!("Simulation mode: OFF");
+                        println!("Simulation mode: OFF (live)");
                     }
-                    _ => println!("Usage: sim on|off"),
+                    "local" => {
+                        sim_mode.set_mode(sim::ExecutionMode::Local);
+                        println!("Simulation mode: LOCAL (Anvil)");
+                    }
+                    _ => println!("Usage: sim on|off|local"),
                 }
             } else {
-                let state = if sim_mode.is_active() { "ON" } else { "OFF" };
-                println!("Simulation mode: {state}");
+                println!("Execution mode: {}", sim_mode.get().label());
             }
         }
         "peers" => {

--- a/agent/src/sim.rs
+++ b/agent/src/sim.rs
@@ -1,38 +1,94 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
-/// Thread-safe simulation mode flag.
-///
-/// Wraps an `Arc<AtomicBool>` so it can be shared across the async event loop
-/// and toggled at runtime via the `sim on|off` command.
-#[derive(Clone, Debug)]
-pub struct SimulationMode {
-    active: Arc<AtomicBool>,
+/// The three execution modes the agent can operate in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ExecutionMode {
+    /// Live mode: real swaps on Sepolia testnet.
+    Live = 0,
+    /// Simulation mode: fake tx hashes, no on-chain execution.
+    Simulate = 1,
+    /// Local mode: real swaps against a local Anvil node (Sepolia fork).
+    Local = 2,
 }
 
-impl SimulationMode {
-    /// Create a new SimulationMode. Pass `true` to start in simulation mode.
-    pub fn new(active: bool) -> Self {
-        Self {
-            active: Arc::new(AtomicBool::new(active)),
+impl ExecutionMode {
+    fn from_u8(val: u8) -> Self {
+        match val {
+            1 => Self::Simulate,
+            2 => Self::Local,
+            _ => Self::Live,
         }
     }
 
-    /// Returns `true` if simulation mode is currently active.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Live => "LIVE (Sepolia)",
+            Self::Simulate => "SIMULATION",
+            Self::Local => "LOCAL (Anvil)",
+        }
+    }
+}
+
+/// Thread-safe execution mode flag.
+///
+/// Wraps an `Arc<AtomicU8>` so it can be shared across the async event loop
+/// and changed at runtime via the `sim on|off|local` command.
+#[derive(Clone, Debug)]
+pub struct SimulationMode {
+    mode: Arc<AtomicU8>,
+}
+
+impl SimulationMode {
+    /// Create from CLI flags.
+    /// - `simulate=false` => Live
+    /// - `simulate=true, local=false` => Simulate
+    /// - `simulate=true, local=true` => Local
+    pub fn new(simulate: bool, local: bool) -> Self {
+        let mode = if !simulate {
+            ExecutionMode::Live
+        } else if local {
+            ExecutionMode::Local
+        } else {
+            ExecutionMode::Simulate
+        };
+        Self {
+            mode: Arc::new(AtomicU8::new(mode as u8)),
+        }
+    }
+
+    /// Returns the current execution mode.
+    pub fn get(&self) -> ExecutionMode {
+        ExecutionMode::from_u8(self.mode.load(Ordering::Relaxed))
+    }
+
+    /// Returns `true` if in Simulate mode (fake hashes, skip execution).
+    /// Returns `false` for Local mode — Local should execute real swaps.
     pub fn is_active(&self) -> bool {
-        self.active.load(Ordering::Relaxed)
+        self.get() == ExecutionMode::Simulate
     }
 
-    /// Explicitly set simulation mode on or off.
+    /// Returns `true` if in Local (Anvil) mode.
+    pub fn is_local(&self) -> bool {
+        self.get() == ExecutionMode::Local
+    }
+
+    /// Set the execution mode directly.
+    pub fn set_mode(&self, mode: ExecutionMode) {
+        self.mode.store(mode as u8, Ordering::Relaxed);
+    }
+
+    /// Legacy setter — `set(true)` => Simulate, `set(false)` => Live.
     pub fn set(&self, active: bool) {
-        self.active.store(active, Ordering::Relaxed);
+        let mode = if active {
+            ExecutionMode::Simulate
+        } else {
+            ExecutionMode::Live
+        };
+        self.set_mode(mode);
     }
 
-    /// Toggle simulation mode and return the new state.
-    pub fn toggle(&self) -> bool {
-        let prev = self.active.fetch_xor(true, Ordering::Relaxed);
-        !prev
-    }
 }
 
 /// Generate a synthetic transaction hash for simulation mode.

--- a/agent/src/tests/sim.rs
+++ b/agent/src/tests/sim.rs
@@ -1,28 +1,17 @@
-use crate::sim::{simulated_tx_hash, SimulationMode};
+use crate::sim::{simulated_tx_hash, ExecutionMode, SimulationMode};
 
 #[test]
 fn simulation_mode_default_off() {
-    let mode = SimulationMode::new(false);
+    let mode = SimulationMode::new(false, false);
     assert!(!mode.is_active());
 }
 
 #[test]
 fn simulation_mode_toggle() {
-    let mode = SimulationMode::new(false);
+    let mode = SimulationMode::new(false, false);
     mode.set(true);
     assert!(mode.is_active());
     mode.set(false);
-    assert!(!mode.is_active());
-}
-
-#[test]
-fn simulation_mode_toggle_method() {
-    let mode = SimulationMode::new(false);
-    let new_state = mode.toggle();
-    assert!(new_state);
-    assert!(mode.is_active());
-    let new_state = mode.toggle();
-    assert!(!new_state);
     assert!(!mode.is_active());
 }
 
@@ -44,4 +33,44 @@ fn simulated_tx_hash_contains_peer_suffix() {
         hash.contains(expected_suffix),
         "hash {hash} should contain peer suffix {expected_suffix}"
     );
+}
+
+#[test]
+fn execution_mode_live_from_flags() {
+    let mode = SimulationMode::new(false, false);
+    assert_eq!(mode.get(), ExecutionMode::Live);
+    assert!(!mode.is_active());
+    assert!(!mode.is_local());
+}
+
+#[test]
+fn execution_mode_simulate_from_flags() {
+    let mode = SimulationMode::new(true, false);
+    assert_eq!(mode.get(), ExecutionMode::Simulate);
+    assert!(mode.is_active());
+    assert!(!mode.is_local());
+}
+
+#[test]
+fn execution_mode_local_from_flags() {
+    let mode = SimulationMode::new(true, true);
+    assert_eq!(mode.get(), ExecutionMode::Local);
+    assert!(!mode.is_active(), "is_active() should be false for Local mode");
+    assert!(mode.is_local());
+}
+
+#[test]
+fn execution_mode_labels() {
+    assert_eq!(ExecutionMode::Live.label(), "LIVE (Sepolia)");
+    assert_eq!(ExecutionMode::Simulate.label(), "SIMULATION");
+    assert_eq!(ExecutionMode::Local.label(), "LOCAL (Anvil)");
+}
+
+#[test]
+fn set_mode_to_local_at_runtime() {
+    let mode = SimulationMode::new(true, false);
+    assert!(mode.is_active());
+    mode.set_mode(ExecutionMode::Local);
+    assert!(mode.is_local());
+    assert!(!mode.is_active());
 }


### PR DESCRIPTION
## Summary
- Add `--simulate --local` flag to execute real swaps against a local Anvil node (Sepolia fork)
- Replace `AtomicBool` with `AtomicU8` + `ExecutionMode` enum (`Live`, `Simulate`, `Local`)
- RPC hardcoded to `localhost:8545` in local mode — ignores `SEPOLIA_RPC_URL` from `.env` to prevent accidental Sepolia transactions
- Add `sim local` runtime command to switch modes on the fly

## Three execution modes

| Mode | CLI | Behavior |
|------|-----|----------|
| Live | `cargo run` | Real swaps on Sepolia, env vars required |
| Simulate | `cargo run -- --simulate` | Fake `0xSIM_...` hashes, no execution |
| Local | `cargo run -- --simulate --local` | Real swaps against Anvil, env vars optional |

## Test plan
- [x] `cargo test` — 34 tests pass
- [x] `cargo run -- --simulate --local` — banner shows `Mode: LOCAL (Anvil)`
- [x] With Anvil running (`anvil --fork-url $SEPOLIA_RPC_URL`): `swap-v2 1` — real tx hash, no Etherscan link
- [x] `cargo run -- --local` (without --simulate) — clap rejects with error
- [x] `sim local` / `sim on` / `sim off` — switches modes at runtime


## Summary by Sourcery

Introduce a configurable execution mode system with support for live, simulated, and local Anvil-backed swaps, and wire it through the CLI, runtime, and tests.

New Features:
- Add a local execution mode that performs real swaps against a local Anvil node via the --simulate --local CLI flags.
- Expose a runtime sim on|off|local command to switch between live, simulated, and local execution modes.
- Display a descriptive execution mode label in the startup banner and status output.

Enhancements:
- Replace the boolean simulation flag with an ExecutionMode enum stored in an AtomicU8 to support multiple execution modes.
- Make local mode always use a localhost Anvil RPC endpoint and a default private key when none is provided, ignoring SEPOLIA_RPC_URL.
- Suppress Etherscan transaction links when running in local mode.

Tests:
- Extend simulation tests to cover the new ExecutionMode enum, flag combinations, labels, and runtime mode changes.