### PR TITLE
ci: add GitHub Actions workflow for Rust and Solidity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  rust:
+    name: Rust (agent)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agent
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: agent
+
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test
+
+  solidity:
+    name: Solidity (contracts)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: foundry-rs/foundry-toolchain@v1
+
+      - run: forge build
+      - run: forge test

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -45,8 +45,8 @@ async fn main() -> Result<()> {
         });
         ("http://localhost:8545".to_string(), key)
     } else if sim_mode.is_active() {
-        let rpc = env::var("SEPOLIA_RPC_URL")
-            .unwrap_or_else(|_| "http://localhost:8545".to_string());
+        let rpc =
+            env::var("SEPOLIA_RPC_URL").unwrap_or_else(|_| "http://localhost:8545".to_string());
         let key = env::var("PRIVATE_KEY").unwrap_or_else(|_| {
             "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string()
         });
@@ -54,8 +54,8 @@ async fn main() -> Result<()> {
     } else {
         let rpc = env::var("SEPOLIA_RPC_URL")
             .expect("SEPOLIA_RPC_URL must be set (use --simulate to skip)");
-        let key = env::var("PRIVATE_KEY")
-            .expect("PRIVATE_KEY must be set (use --simulate to skip)");
+        let key =
+            env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set (use --simulate to skip)");
         (rpc, key)
     };
 
@@ -185,12 +185,10 @@ async fn handle_input(
         "dial" => {
             if let Some(addr) = parts.get(1) {
                 match addr.parse::<Multiaddr>() {
-                    Ok(remote) => {
-                        match swarm.dial(remote.clone()) {
-                            Ok(_) => println!("Dialing {remote}..."),
-                            Err(e) => println!("Dial failed: {e}"),
-                        }
-                    }
+                    Ok(remote) => match swarm.dial(remote.clone()) {
+                        Ok(_) => println!("Dialing {remote}..."),
+                        Err(e) => println!("Dial failed: {e}"),
+                    },
                     Err(e) => println!("Invalid multiaddr: {e}"),
                 }
             } else {
@@ -349,11 +347,7 @@ fn publish_message(
             return;
         }
     };
-    if let Err(e) = swarm
-        .behaviour_mut()
-        .gossipsub
-        .publish(topic.clone(), json)
-    {
+    if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic.clone(), json) {
         println!("Publish error: {e}");
     }
 }
@@ -368,7 +362,10 @@ async fn execute_pending_swap(
     if sim_mode.is_active() {
         let peer_id_str = swarm.local_peer_id().to_string();
         let tx_hash = sim::simulated_tx_hash(&peer_id_str);
-        println!("[SIM] {} swap: {} {}", swap.version, swap.amount_str, swap.direction);
+        println!(
+            "[SIM] {} swap: {} {}",
+            swap.version, swap.amount_str, swap.direction
+        );
         println!("[SIM] tx: {tx_hash}");
 
         let msg = AgentMessage::SwapExecuted {
@@ -379,7 +376,10 @@ async fn execute_pending_swap(
         };
         publish_message(swarm, topic, &msg);
     } else {
-        println!("Executing {} swap: {} {}...", swap.version, swap.amount_str, swap.direction);
+        println!(
+            "Executing {} swap: {} {}...",
+            swap.version, swap.amount_str, swap.direction
+        );
 
         let amount = match swap.amount_str.parse::<u64>() {
             Ok(a) => U256::from(a) * U256::from(10u64.pow(18)),
@@ -425,10 +425,7 @@ fn handle_swarm_event(
         SwarmEvent::Behaviour(AgentBehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
             for (peer_id, _addr) in list {
                 println!("mDNS discovered peer: {peer_id}");
-                swarm
-                    .behaviour_mut()
-                    .gossipsub
-                    .add_explicit_peer(&peer_id);
+                swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
             }
         }
         SwarmEvent::Behaviour(AgentBehaviourEvent::Mdns(mdns::Event::Expired(list))) => {
@@ -440,13 +437,11 @@ fn handle_swarm_event(
                     .remove_explicit_peer(&peer_id);
             }
         }
-        SwarmEvent::Behaviour(AgentBehaviourEvent::Gossipsub(
-            gossipsub::Event::Message {
-                propagation_source: peer_id,
-                message,
-                ..
-            },
-        )) => {
+        SwarmEvent::Behaviour(AgentBehaviourEvent::Gossipsub(gossipsub::Event::Message {
+            propagation_source: peer_id,
+            message,
+            ..
+        })) => {
             if let Ok(agent_msg) = serde_json::from_slice::<AgentMessage>(&message.data) {
                 match agent_msg {
                     AgentMessage::Chat { content } => {
@@ -464,9 +459,7 @@ fn handle_swarm_event(
                         println!("  https://sepolia.etherscan.io/tx/{tx_hash}");
                     }
                     AgentMessage::SwapRequest { direction, amount } => {
-                        println!(
-                            "[REQUEST] Peer {peer_id} requests swap: {amount} ({direction})"
-                        );
+                        println!("[REQUEST] Peer {peer_id} requests swap: {amount} ({direction})");
                     }
                     AgentMessage::SwapIntent {
                         agent,
@@ -542,10 +535,7 @@ fn handle_swarm_event(
         }
         SwarmEvent::ConnectionEstablished { peer_id, .. } => {
             println!("Connected to peer: {peer_id}");
-            swarm
-                .behaviour_mut()
-                .gossipsub
-                .add_explicit_peer(&peer_id);
+            swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
             // Publish our identity attestation so the new peer can verify our EOA
             publish_message(swarm, topic, attestation_msg);
         }

--- a/agent/src/network.rs
+++ b/agent/src/network.rs
@@ -70,18 +70,16 @@ pub fn build_swarm() -> Result<Swarm<AgentBehaviour>> {
                 .validation_mode(gossipsub::ValidationMode::Strict)
                 .message_id_fn(message_id_fn)
                 .build()
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
 
             let gossipsub = gossipsub::Behaviour::new(
                 gossipsub::MessageAuthenticity::Signed(key.clone()),
                 gossipsub_config,
             )
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
-            let mdns = mdns::tokio::Behaviour::new(
-                mdns::Config::default(),
-                key.public().to_peer_id(),
-            )?;
+            let mdns =
+                mdns::tokio::Behaviour::new(mdns::Config::default(), key.public().to_peer_id())?;
 
             Ok(AgentBehaviour { gossipsub, mdns })
         })?

--- a/agent/src/sim.rs
+++ b/agent/src/sim.rs
@@ -88,7 +88,6 @@ impl SimulationMode {
         };
         self.set_mode(mode);
     }
-
 }
 
 /// Generate a synthetic transaction hash for simulation mode.

--- a/agent/src/tests/identity.rs
+++ b/agent/src/tests/identity.rs
@@ -5,8 +5,7 @@ use crate::identity::{IdentityBinding, PeerRegistry};
 // Test private key (Hardhat account #0 — never use with real funds)
 const TEST_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 // Corresponding EOA for the test key
-const TEST_EOA: alloy::primitives::Address =
-    address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+const TEST_EOA: alloy::primitives::Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
 #[tokio::test]
 async fn attestation_roundtrip() {
@@ -20,7 +19,10 @@ async fn attestation_roundtrip() {
     assert!(!binding.signature.is_empty());
 
     // Verify the signature
-    assert!(binding.verify().expect("verify"), "signature should be valid");
+    assert!(
+        binding.verify().expect("verify"),
+        "signature should be valid"
+    );
 }
 
 #[tokio::test]

--- a/agent/src/tests/mod.rs
+++ b/agent/src/tests/mod.rs
@@ -1,4 +1,4 @@
 mod identity;
 mod network;
-mod uniswap;
 mod sim;
+mod uniswap;

--- a/agent/src/tests/sim.rs
+++ b/agent/src/tests/sim.rs
@@ -55,7 +55,10 @@ fn execution_mode_simulate_from_flags() {
 fn execution_mode_local_from_flags() {
     let mode = SimulationMode::new(true, true);
     assert_eq!(mode.get(), ExecutionMode::Local);
-    assert!(!mode.is_active(), "is_active() should be false for Local mode");
+    assert!(
+        !mode.is_active(),
+        "is_active() should be false for Local mode"
+    );
     assert!(mode.is_local());
 }
 

--- a/agent/src/tests/uniswap.rs
+++ b/agent/src/tests/uniswap.rs
@@ -89,5 +89,8 @@ fn pool_key_v2_same_tokens() {
 
 #[test]
 fn hook_v2_address() {
-    assert_eq!(HOOK_V2, address!("A8760B755c67c5C75A8A60ED7E3713eA2448D0C0"));
+    assert_eq!(
+        HOOK_V2,
+        address!("A8760B755c67c5C75A8A60ED7E3713eA2448D0C0")
+    );
 }

--- a/agent/src/uniswap.rs
+++ b/agent/src/uniswap.rs
@@ -1,3 +1,6 @@
+// sol! macro generates functions matching the Solidity ABI — argument counts are dictated by the contract interface
+#![allow(clippy::too_many_arguments)]
+
 use alloy::hex;
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, Bytes, Signed, Uint, U256};
@@ -10,8 +13,7 @@ use anyhow::Result;
 // Contract addresses (Sepolia)
 pub const TKNA: Address = Address::new(hex!("7546360e0011Bb0B52ce10E21eF0E9341453fE71"));
 pub const TKNB: Address = Address::new(hex!("F6d91478e66CE8161e15Da103003F3BA6d2bab80"));
-pub const SWAP_ROUTER: Address =
-    Address::new(hex!("f13D190e9117920c703d79B5F33732e10049b115"));
+pub const SWAP_ROUTER: Address = Address::new(hex!("f13D190e9117920c703d79B5F33732e10049b115"));
 pub const HOOK: Address = Address::new(hex!("5D4505AA950a73379B8E9f1116976783Ba8340C0"));
 
 // V2 hook (dynamic fees + hookData agent tracking)
@@ -88,11 +90,7 @@ impl SwapClient {
         }
     }
 
-    pub async fn execute_swap(
-        &self,
-        amount: U256,
-        zero_for_one: bool,
-    ) -> Result<String> {
+    pub async fn execute_swap(&self, amount: U256, zero_for_one: bool) -> Result<String> {
         let signer: PrivateKeySigner = self.private_key.parse()?;
         let receiver = signer.address();
         let wallet = EthereumWallet::from(signer);
@@ -153,11 +151,7 @@ impl SwapClient {
     /// Execute a swap on the V2 pool.
     /// Unlike V1, this ABI-encodes the agent's EOA address into hookData so the
     /// AgentCounterV2 hook can track the real agent (not the router address).
-    pub async fn execute_swap_v2(
-        &self,
-        amount: U256,
-        zero_for_one: bool,
-    ) -> Result<String> {
+    pub async fn execute_swap_v2(&self, amount: U256, zero_for_one: bool) -> Result<String> {
         let signer: PrivateKeySigner = self.private_key.parse()?;
         let receiver = signer.address();
         let wallet = EthereumWallet::from(signer);
@@ -219,11 +213,7 @@ impl SwapClient {
         let hook = IAgentCounterV2::new(HOOK_V2, &provider);
         let pool_key = Self::pool_key_v2();
 
-        let pool_count = hook
-            .getPoolSwapCount(pool_key.clone())
-            .call()
-            .await?
-            ._0;
+        let pool_count = hook.getPoolSwapCount(pool_key.clone()).call().await?._0;
 
         let agent_count = hook
             .getAgentSwapCount(pool_key.clone(), agent_addr)
@@ -231,11 +221,7 @@ impl SwapClient {
             .await?
             ._0;
 
-        let agent_fee = hook
-            .getAgentFee(pool_key, agent_addr)
-            .call()
-            .await?
-            ._0;
+        let agent_fee = hook.getAgentFee(pool_key, agent_addr).call().await?._0;
 
         let fee_pct = f64::from(agent_fee) / 10000.0;
         Ok(format!(
@@ -256,11 +242,7 @@ impl SwapClient {
         let hook = IAgentCounter::new(HOOK, &provider);
         let pool_key = Self::pool_key();
 
-        let pool_count = hook
-            .getPoolSwapCount(pool_key.clone())
-            .call()
-            .await?
-            ._0;
+        let pool_count = hook.getPoolSwapCount(pool_key.clone()).call().await?._0;
 
         let agent_count = hook
             .getAgentSwapCount(pool_key, agent_addr)


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with two parallel jobs: **Rust** (fmt, clippy, test) and **Solidity** (forge build, forge test)
- Fix clippy warnings: `std::io::Error::other` simplification in `network.rs`, `too_many_arguments` allow for `sol!` macro in `uniswap.rs`
- Fix `cargo fmt` formatting across agent codebase

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 38 tests pass
- [x] `forge build` — clean
- [x] `forge test` — 10 tests pass

Closes #15

## Summary by Sourcery

Add GitHub Actions CI for Rust and Solidity while cleaning up formatting and minor lint issues across the agent codebase.

Enhancements:
- Reformat Rust agent sources and tests to comply with cargo fmt and simplify minor error-handling and logging patterns.

Build:
- Introduce a CI workflow that runs Rust formatting, clippy, and tests for the agent and Foundry build and tests for Solidity contracts.

Tests:
- Tidy test modules and assertions without changing test coverage or behavior.