### PR TITLE
feat: reputation scoring, peer trust & conditional swaps

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -2,6 +2,7 @@ mod archival;
 mod cli;
 mod identity;
 mod network;
+mod reputation;
 mod sim;
 mod uniswap;
 
@@ -24,6 +25,7 @@ use archival::{LogArchiver, LogEntry};
 use cli::Cli;
 use identity::{IdentityBinding, PeerRegistry};
 use network::{AgentBehaviourEvent, AgentMessage, INTENT_TOPIC, TOPIC};
+use reputation::ReputationStore;
 use sim::SimulationMode;
 use uniswap::SwapClient;
 
@@ -71,6 +73,14 @@ async fn main() -> Result<()> {
     swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
     swarm.behaviour_mut().gossipsub.subscribe(&intent_topic)?;
 
+    // Activate gossipsub peer scoring with application-specific score (P5)
+    let (score_params, score_thresholds) = network::build_peer_score_params();
+    swarm
+        .behaviour_mut()
+        .gossipsub
+        .with_peer_score(score_params, score_thresholds)
+        .expect("valid peer score params");
+
     // Listen on all interfaces
     swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse::<Multiaddr>()?)?;
     swarm.listen_on("/ip4/0.0.0.0/udp/0/quic-v1".parse::<Multiaddr>()?)?;
@@ -96,6 +106,7 @@ async fn main() -> Result<()> {
 
     let mut peer_registry = PeerRegistry::new();
     peer_registry.register(own_binding);
+    let reputation_store = ReputationStore::new();
 
     // Dial a remote peer if provided as CLI argument
     if let Some(addr) = cli.dial {
@@ -120,9 +131,23 @@ async fn main() -> Result<()> {
             loop {
                 tokio::select! {
                     event = swarm.select_next_some() => {
-                        handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver);
+                        handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store);
                     }
                     _ = &mut flush_deadline => break,
+                }
+            }
+
+            // Check conditions before executing
+            if !swap.conditions.is_empty() {
+                let peer_id_str = swarm.local_peer_id().to_string();
+                match swap.conditions.evaluate(&peer_id_str, &reputation_store) {
+                    reputation::ConditionResult::Passed => {
+                        println!("[CSWAP] Conditions met, executing...");
+                    }
+                    reputation::ConditionResult::Failed(reason) => {
+                        println!("[CSWAP] REJECTED: {reason}");
+                        continue;
+                    }
                 }
             }
 
@@ -142,11 +167,11 @@ async fn main() -> Result<()> {
         tokio::select! {
             line = stdin.next_line() => {
                 if let Ok(Some(line)) = line {
-                    pending_swap = handle_input(&line, &topic, &intent_topic, &mut swarm, &swap_client, &peer_registry, &sim_mode, &archiver).await;
+                    pending_swap = handle_input(&line, &topic, &intent_topic, &mut swarm, &swap_client, &peer_registry, &sim_mode, &archiver, &reputation_store).await;
                 }
             }
             event = swarm.select_next_some() => {
-                handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver);
+                handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store);
             }
         }
     }
@@ -159,6 +184,7 @@ struct PendingSwap {
     amount_str: String,
     direction: String,
     version: String,
+    conditions: reputation::SwapConditions,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -171,6 +197,7 @@ async fn handle_input(
     peer_registry: &PeerRegistry,
     sim_mode: &SimulationMode,
     archiver: &LogArchiver,
+    reputation_store: &ReputationStore,
 ) -> Option<PendingSwap> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
@@ -186,15 +213,20 @@ async fn handle_input(
             println!("  swap-b <amount>     - Swap TKNB -> TKNA (V1 pool)");
             println!("  swap-v2 <amount>    - Swap TKNA -> TKNB (V2 pool, fee rebates)");
             println!("  swap-v2-b <amount>  - Swap TKNB -> TKNA (V2 pool, fee rebates)");
+            println!("  cswap <amount> <a2b|b2a> [options] - Conditional swap");
+            println!("    --min-rep <score>   Minimum reputation score (0.0-1.0)");
+            println!("    --min-price <val>   Price floor");
+            println!("    --max-price <val>   Price ceiling");
             println!("  status              - Query V1 on-chain swap counts");
             println!("  status-v2           - Query V2 swap counts + your fee tier");
             println!("  intent <amount> <a2b|b2a> [min] [max] - Broadcast swap intent");
+            println!("  reputation [peer]   - Show reputation scores");
             println!("  sim on|off|local    - Set execution mode (sim/live/local-anvil)");
             println!("  archive             - Flush log buffer to Filecoin via sidecar");
             println!("  retrieve <pieceCid> - Retrieve archived data from Filecoin");
             println!("  log-status          - Show log buffer count and sidecar URL");
             println!("  who                 - Show your PeerId and EOA");
-            println!("  peers               - List all verified peer identities");
+            println!("  peers               - List all verified peer identities + trust");
             println!("  help                - Show this message");
             println!("  <text>              - Send chat message to peers");
         }
@@ -249,6 +281,7 @@ async fn handle_input(
                 amount_str: amount_str.to_string(),
                 direction: direction.to_string(),
                 version: version.to_string(),
+                conditions: reputation::SwapConditions::default(),
             });
         }
         "status" => match swap_client.get_swap_counts().await {
@@ -364,8 +397,125 @@ async fn handle_input(
             } else {
                 println!("Verified peers ({}):", bindings.len());
                 for binding in bindings.values() {
-                    println!("  {} -> {}", binding.peer_id, binding.eoa);
+                    let trust = reputation_store.trust_level(&binding.peer_id);
+                    let score = reputation_store.score(&binding.peer_id);
+                    println!(
+                        "  {} -> {} [Trust: {} | Score: {:.2}]",
+                        binding.peer_id, binding.eoa, trust, score
+                    );
                 }
+            }
+        }
+        "reputation" | "rep" => {
+            if let Some(peer_id) = parts.get(1) {
+                println!("{}", reputation_store.summary(peer_id.trim()));
+            } else {
+                let all = reputation_store.all();
+                if all.is_empty() {
+                    println!("No reputation data yet.");
+                } else {
+                    println!("Peer reputations ({}):", all.len());
+                    for (pid, rep) in &all {
+                        println!(
+                            "  {} — Score: {:.2} | Trust: {} | Swaps: {} | ID: {}",
+                            pid,
+                            rep.composite_score(),
+                            rep.trust_level(),
+                            rep.swap_count,
+                            if rep.identity_verified {
+                                "verified"
+                            } else {
+                                "unverified"
+                            }
+                        );
+                    }
+                }
+            }
+        }
+        "cswap" => {
+            if let Some(args) = parts.get(1) {
+                let tokens: Vec<&str> = args.split_whitespace().collect();
+                if tokens.len() < 2 {
+                    println!("Usage: cswap <amount> <a2b|b2a> [--min-rep <score>] [--min-price <val>] [--max-price <val>]");
+                    return None;
+                }
+                let amount = tokens[0];
+                let direction = match tokens[1] {
+                    "a2b" => "TKNA -> TKNB",
+                    "b2a" => "TKNB -> TKNA",
+                    other => {
+                        println!("Invalid direction '{other}'. Use a2b or b2a.");
+                        return None;
+                    }
+                };
+                let zero_for_one = tokens[1] == "a2b";
+
+                let mut conditions = reputation::SwapConditions::default();
+                let mut i = 2;
+                while i < tokens.len() {
+                    match tokens[i] {
+                        "--min-rep" => {
+                            if let Some(val) = tokens.get(i + 1) {
+                                conditions.min_reputation = val.parse().ok();
+                                i += 2;
+                            } else {
+                                i += 1;
+                            }
+                        }
+                        "--min-price" => {
+                            conditions.min_price = tokens.get(i + 1).map(|s| s.to_string());
+                            i += 2;
+                        }
+                        "--max-price" => {
+                            conditions.max_price = tokens.get(i + 1).map(|s| s.to_string());
+                            i += 2;
+                        }
+                        _ => {
+                            i += 1;
+                        }
+                    }
+                }
+
+                let intent_msg = AgentMessage::SwapIntent {
+                    agent: swarm.local_peer_id().to_string(),
+                    direction: direction.to_string(),
+                    amount: amount.to_string(),
+                    min_price: conditions.min_price.clone(),
+                    max_price: conditions.max_price.clone(),
+                    timestamp: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs(),
+                };
+                publish_message(swarm, intent_topic, &intent_msg);
+
+                let mut cond_parts = Vec::new();
+                if let Some(rep) = conditions.min_reputation {
+                    cond_parts.push(format!("min-rep: {rep:.2}"));
+                }
+                if let Some(ref p) = conditions.min_price {
+                    cond_parts.push(format!("min-price: {p}"));
+                }
+                if let Some(ref p) = conditions.max_price {
+                    cond_parts.push(format!("max-price: {p}"));
+                }
+                let cond_str = if cond_parts.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({})", cond_parts.join(", "))
+                };
+                println!("[CSWAP] Broadcast conditional intent: {amount} {direction}{cond_str}");
+
+                return Some(PendingSwap {
+                    is_v2: false,
+                    zero_for_one,
+                    amount_str: amount.to_string(),
+                    direction: direction.to_string(),
+                    version: "V1".to_string(),
+                    conditions,
+                });
+            } else {
+                println!("Usage: cswap <amount> <a2b|b2a> [--min-rep <score>] [--min-price <val>] [--max-price <val>]");
             }
         }
         _ => {
@@ -477,6 +627,7 @@ fn handle_swarm_event(
     attestation_msg: &AgentMessage,
     peer_registry: &mut PeerRegistry,
     archiver: &LogArchiver,
+    reputation_store: &ReputationStore,
 ) {
     match event {
         SwarmEvent::Behaviour(AgentBehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
@@ -514,6 +665,14 @@ fn handle_swarm_event(
                             "[SWAP] Agent {agent} swapped {amount} ({direction}) tx: {tx_hash}"
                         );
                         println!("  https://sepolia.etherscan.io/tx/{tx_hash}");
+                        reputation_store.record_swap(&agent);
+                        if let Ok(pid) = agent.parse::<libp2p::PeerId>() {
+                            let app_score = reputation_store.score(&agent) * 100.0;
+                            swarm
+                                .behaviour_mut()
+                                .gossipsub
+                                .set_application_score(&pid, app_score);
+                        }
                     }
                     AgentMessage::SwapRequest { direction, amount } => {
                         println!("[REQUEST] Peer {peer_id} requests swap: {amount} ({direction})");
@@ -539,6 +698,14 @@ fn handle_swarm_event(
                         println!(
                             "[INTENT] Agent {agent} intends to swap {amount} ({direction}){bounds} at {time_str}"
                         );
+                        reputation_store.record_intent(&agent);
+                        if let Ok(pid) = agent.parse::<libp2p::PeerId>() {
+                            let app_score = reputation_store.score(&agent) * 100.0;
+                            swarm
+                                .behaviour_mut()
+                                .gossipsub
+                                .set_application_score(&pid, app_score);
+                        }
                     }
                     // Verify incoming identity attestation and register if valid
                     AgentMessage::IdentityAttestation {
@@ -565,6 +732,7 @@ fn handle_swarm_event(
                                     attested_peer_id, eoa_addr
                                 );
                                 peer_registry.register(binding);
+                                reputation_store.set_identity_verified(&attested_peer_id, true);
                                 archiver.log(LogEntry::identity_attestation(
                                     &attested_peer_id,
                                     &format!("{eoa_addr}"),

--- a/agent/src/network.rs
+++ b/agent/src/network.rs
@@ -49,6 +49,46 @@ pub enum AgentMessage {
     },
 }
 
+/// Build gossipsub peer scoring parameters tuned for swap agent network.
+/// Returns params and thresholds for use with `Behaviour::with_peer_score`.
+pub fn build_peer_score_params() -> (gossipsub::PeerScoreParams, gossipsub::PeerScoreThresholds) {
+    let mut params = gossipsub::PeerScoreParams::default();
+
+    let topic_params = gossipsub::TopicScoreParams {
+        topic_weight: 1.0,
+        // P1: reward time in mesh
+        time_in_mesh_weight: 0.5,
+        time_in_mesh_quantum: Duration::from_secs(1),
+        time_in_mesh_cap: 100.0,
+        // P2: reward first message deliveries
+        first_message_deliveries_weight: 1.0,
+        first_message_deliveries_decay: 0.97,
+        first_message_deliveries_cap: 100.0,
+        // P3: disabled — too aggressive for small demo networks (<10 peers)
+        mesh_message_deliveries_weight: 0.0,
+        ..Default::default()
+    };
+
+    let swap_topic_hash = gossipsub::IdentTopic::new(TOPIC).hash();
+    let intent_topic_hash = gossipsub::IdentTopic::new(INTENT_TOPIC).hash();
+    params.topics.insert(swap_topic_hash, topic_params.clone());
+    params.topics.insert(intent_topic_hash, topic_params);
+
+    // P5: application-specific score weight (fed by ReputationStore)
+    params.app_specific_weight = 10.0;
+
+    // Lenient thresholds for a demo network
+    let thresholds = gossipsub::PeerScoreThresholds {
+        gossip_threshold: -100.0,
+        publish_threshold: -200.0,
+        graylist_threshold: -400.0,
+        accept_px_threshold: 0.0,
+        opportunistic_graft_threshold: 5.0,
+    };
+
+    (params, thresholds)
+}
+
 pub fn build_swarm() -> Result<Swarm<AgentBehaviour>> {
     let swarm = SwarmBuilder::with_new_identity()
         .with_tokio()

--- a/agent/src/reputation.rs
+++ b/agent/src/reputation.rs
@@ -1,0 +1,297 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Weights for each reputation factor. Sum to 1.0.
+pub const WEIGHT_SWAP_COUNT: f64 = 0.40;
+pub const WEIGHT_IDENTITY: f64 = 0.20;
+pub const WEIGHT_FOLLOW_THROUGH: f64 = 0.25;
+pub const WEIGHT_RECENCY: f64 = 0.15;
+
+/// Maximum raw swap count for normalization (score saturates here).
+pub const MAX_SWAP_COUNT: f64 = 50.0;
+
+/// Half-life for recency decay in seconds (24 hours).
+pub const RECENCY_HALF_LIFE: f64 = 86400.0;
+
+/// Per-peer reputation data, derived from gossipsub messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerReputation {
+    pub peer_id: String,
+    /// Count of SwapExecuted messages seen from this peer.
+    pub swap_count: u64,
+    /// Count of SwapIntent messages seen from this peer.
+    pub intent_count: u64,
+    /// Whether peer has a verified identity in PeerRegistry.
+    pub identity_verified: bool,
+    /// Unix timestamp of last observed activity (swap or intent).
+    pub last_active: u64,
+}
+
+impl PeerReputation {
+    pub fn new(peer_id: String) -> Self {
+        Self {
+            peer_id,
+            swap_count: 0,
+            intent_count: 0,
+            identity_verified: false,
+            last_active: 0,
+        }
+    }
+
+    /// Compute normalized composite score in [0.0, 1.0].
+    pub fn composite_score(&self) -> f64 {
+        let swap_score = (self.swap_count as f64 / MAX_SWAP_COUNT).min(1.0);
+        let identity_score = if self.identity_verified { 1.0 } else { 0.0 };
+        let follow_through = if self.intent_count == 0 {
+            1.0 // no intents = neutral, not penalized
+        } else {
+            (self.swap_count as f64 / self.intent_count as f64).min(1.0)
+        };
+        let recency = self.recency_score();
+
+        WEIGHT_SWAP_COUNT * swap_score
+            + WEIGHT_IDENTITY * identity_score
+            + WEIGHT_FOLLOW_THROUGH * follow_through
+            + WEIGHT_RECENCY * recency
+    }
+
+    /// Exponential decay based on time since last activity.
+    /// Returns 1.0 if active now, decays with 24-hour half-life.
+    pub fn recency_score(&self) -> f64 {
+        if self.last_active == 0 {
+            return 0.0;
+        }
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let elapsed = now.saturating_sub(self.last_active) as f64;
+        (-elapsed * 2.0_f64.ln() / RECENCY_HALF_LIFE).exp()
+    }
+
+    /// Compute recency score relative to a specific reference timestamp.
+    /// Used for deterministic testing.
+    pub fn recency_score_at(&self, now_secs: u64) -> f64 {
+        if self.last_active == 0 {
+            return 0.0;
+        }
+        let elapsed = now_secs.saturating_sub(self.last_active) as f64;
+        (-elapsed * 2.0_f64.ln() / RECENCY_HALF_LIFE).exp()
+    }
+
+    pub fn trust_level(&self) -> TrustLevel {
+        let score = self.composite_score();
+        TrustLevel::from_score(score)
+    }
+}
+
+/// Trust tier derived from the composite score.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TrustLevel {
+    Unknown,
+    Low,
+    Medium,
+    High,
+    Trusted,
+}
+
+impl TrustLevel {
+    pub fn from_score(score: f64) -> Self {
+        match score {
+            s if s <= 0.0 => TrustLevel::Unknown,
+            s if s <= 0.3 => TrustLevel::Low,
+            s if s <= 0.6 => TrustLevel::Medium,
+            s if s <= 0.85 => TrustLevel::High,
+            _ => TrustLevel::Trusted,
+        }
+    }
+}
+
+impl fmt::Display for TrustLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TrustLevel::Unknown => write!(f, "Unknown"),
+            TrustLevel::Low => write!(f, "Low"),
+            TrustLevel::Medium => write!(f, "Medium"),
+            TrustLevel::High => write!(f, "High"),
+            TrustLevel::Trusted => write!(f, "Trusted"),
+        }
+    }
+}
+
+/// Conditions that must be met before a conditional swap executes.
+#[derive(Debug, Clone, Default)]
+pub struct SwapConditions {
+    /// Minimum reputation score required (0.0-1.0).
+    pub min_reputation: Option<f64>,
+    /// Price lower bound (informational, broadcast in intent).
+    pub min_price: Option<String>,
+    /// Price upper bound (informational, broadcast in intent).
+    pub max_price: Option<String>,
+}
+
+impl SwapConditions {
+    pub fn is_empty(&self) -> bool {
+        self.min_reputation.is_none() && self.min_price.is_none() && self.max_price.is_none()
+    }
+
+    /// Evaluate conditions against current state.
+    pub fn evaluate(
+        &self,
+        own_peer_id: &str,
+        reputation_store: &ReputationStore,
+    ) -> ConditionResult {
+        if let Some(min_rep) = self.min_reputation {
+            let own_score = reputation_store.score(own_peer_id);
+            if own_score < min_rep {
+                return ConditionResult::Failed(format!(
+                    "Reputation too low: {:.2} < {:.2} threshold",
+                    own_score, min_rep
+                ));
+            }
+        }
+
+        if let Some(ref min_p) = self.min_price {
+            if min_p.parse::<f64>().is_err() {
+                return ConditionResult::Failed(format!("Invalid min_price: {min_p}"));
+            }
+        }
+        if let Some(ref max_p) = self.max_price {
+            if max_p.parse::<f64>().is_err() {
+                return ConditionResult::Failed(format!("Invalid max_price: {max_p}"));
+            }
+        }
+
+        ConditionResult::Passed
+    }
+}
+
+/// Result of condition evaluation.
+#[derive(Debug, Clone)]
+pub enum ConditionResult {
+    Passed,
+    Failed(String),
+}
+
+impl ConditionResult {
+    pub fn is_passed(&self) -> bool {
+        matches!(self, ConditionResult::Passed)
+    }
+}
+
+/// Thread-safe reputation store, mirrors the Arc<Mutex<_>> pattern
+/// used by LogArchiver in archival.rs.
+#[derive(Clone, Debug)]
+pub struct ReputationStore {
+    peers: Arc<Mutex<HashMap<String, PeerReputation>>>,
+}
+
+impl ReputationStore {
+    pub fn new() -> Self {
+        Self {
+            peers: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    /// Record a SwapExecuted event for a peer.
+    pub fn record_swap(&self, peer_id: &str) {
+        let mut peers = self.peers.lock().unwrap();
+        let rep = peers
+            .entry(peer_id.to_string())
+            .or_insert_with(|| PeerReputation::new(peer_id.to_string()));
+        rep.swap_count += 1;
+        rep.last_active = Self::now_secs();
+    }
+
+    /// Record a SwapIntent event for a peer.
+    pub fn record_intent(&self, peer_id: &str) {
+        let mut peers = self.peers.lock().unwrap();
+        let rep = peers
+            .entry(peer_id.to_string())
+            .or_insert_with(|| PeerReputation::new(peer_id.to_string()));
+        rep.intent_count += 1;
+        rep.last_active = Self::now_secs();
+    }
+
+    /// Update identity verification status for a peer.
+    pub fn set_identity_verified(&self, peer_id: &str, verified: bool) {
+        let mut peers = self.peers.lock().unwrap();
+        let rep = peers
+            .entry(peer_id.to_string())
+            .or_insert_with(|| PeerReputation::new(peer_id.to_string()));
+        rep.identity_verified = verified;
+        if verified {
+            rep.last_active = Self::now_secs();
+        }
+    }
+
+    /// Get the reputation for a specific peer.
+    pub fn get(&self, peer_id: &str) -> Option<PeerReputation> {
+        self.peers.lock().unwrap().get(peer_id).cloned()
+    }
+
+    /// Get all peer reputations.
+    pub fn all(&self) -> HashMap<String, PeerReputation> {
+        self.peers.lock().unwrap().clone()
+    }
+
+    /// Get composite score for a peer (0.0 if unknown).
+    pub fn score(&self, peer_id: &str) -> f64 {
+        self.peers
+            .lock()
+            .unwrap()
+            .get(peer_id)
+            .map(|r| r.composite_score())
+            .unwrap_or(0.0)
+    }
+
+    /// Get trust level for a peer.
+    pub fn trust_level(&self, peer_id: &str) -> TrustLevel {
+        self.peers
+            .lock()
+            .unwrap()
+            .get(peer_id)
+            .map(|r| r.trust_level())
+            .unwrap_or(TrustLevel::Unknown)
+    }
+
+    /// Display-formatted reputation summary for a peer.
+    pub fn summary(&self, peer_id: &str) -> String {
+        let peers = self.peers.lock().unwrap();
+        match peers.get(peer_id) {
+            Some(rep) => {
+                let score = rep.composite_score();
+                let level = rep.trust_level();
+                let follow = if rep.intent_count > 0 {
+                    format!(
+                        "{:.0}%",
+                        (rep.swap_count as f64 / rep.intent_count as f64).min(1.0) * 100.0
+                    )
+                } else {
+                    "n/a".to_string()
+                };
+                format!(
+                    "Score: {:.2} | Trust: {} | Swaps: {} | Intents: {} | Follow-through: {} | ID: {}",
+                    score,
+                    level,
+                    rep.swap_count,
+                    rep.intent_count,
+                    follow,
+                    if rep.identity_verified { "verified" } else { "unverified" }
+                )
+            }
+            None => "No reputation data".to_string(),
+        }
+    }
+}

--- a/agent/src/tests/mod.rs
+++ b/agent/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod archival;
 mod identity;
 mod network;
+mod reputation;
 mod sim;
 mod uniswap;

--- a/agent/src/tests/reputation.rs
+++ b/agent/src/tests/reputation.rs
@@ -1,0 +1,334 @@
+use crate::reputation::{
+    ConditionResult, PeerReputation, ReputationStore, SwapConditions, TrustLevel,
+    WEIGHT_FOLLOW_THROUGH, WEIGHT_IDENTITY, WEIGHT_RECENCY, WEIGHT_SWAP_COUNT,
+};
+
+#[test]
+fn weights_sum_to_one() {
+    let sum = WEIGHT_SWAP_COUNT + WEIGHT_IDENTITY + WEIGHT_FOLLOW_THROUGH + WEIGHT_RECENCY;
+    assert!((sum - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn new_peer_has_zero_score() {
+    let rep = PeerReputation::new("peer1".to_string());
+    assert_eq!(rep.swap_count, 0);
+    assert_eq!(rep.intent_count, 0);
+    assert!(!rep.identity_verified);
+    // Only follow-through contributes (neutral = 1.0 * 0.25 = 0.25),
+    // but recency is 0 (no activity), so score = 0.25
+    let score = rep.composite_score();
+    assert!((score - WEIGHT_FOLLOW_THROUGH).abs() < 0.01);
+}
+
+#[test]
+fn identity_verified_increases_score() {
+    let mut rep = PeerReputation::new("peer1".to_string());
+    let before = rep.composite_score();
+    rep.identity_verified = true;
+    let after = rep.composite_score();
+    assert!(after > before);
+    assert!((after - before - WEIGHT_IDENTITY).abs() < 0.01);
+}
+
+#[test]
+fn swap_count_increases_score() {
+    let mut rep = PeerReputation::new("peer1".to_string());
+    rep.last_active = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let before = rep.composite_score();
+    rep.swap_count = 10;
+    let after = rep.composite_score();
+    assert!(after > before);
+}
+
+#[test]
+fn max_swap_count_saturates() {
+    let mut rep = PeerReputation::new("peer1".to_string());
+    rep.swap_count = 50;
+    let score_at_max = rep.composite_score();
+    rep.swap_count = 100;
+    let score_beyond = rep.composite_score();
+    // Swap component should be the same once saturated
+    assert!((score_at_max - score_beyond).abs() < 0.01);
+}
+
+#[test]
+fn follow_through_ratio_perfect() {
+    let mut rep = PeerReputation::new("peer1".to_string());
+    rep.intent_count = 10;
+    rep.swap_count = 10;
+    // Follow-through = 10/10 = 1.0 → full weight
+    let score = rep.composite_score();
+    let swap_component = WEIGHT_SWAP_COUNT * (10.0 / 50.0);
+    let follow_component = WEIGHT_FOLLOW_THROUGH * 1.0;
+    assert!(score >= swap_component + follow_component - 0.01);
+}
+
+#[test]
+fn follow_through_ratio_poor() {
+    let mut rep = PeerReputation::new("peer1".to_string());
+    rep.intent_count = 10;
+    rep.swap_count = 2;
+    // Follow-through = 2/10 = 0.2
+    let follow = rep.swap_count as f64 / rep.intent_count as f64;
+    assert!((follow - 0.2).abs() < f64::EPSILON);
+}
+
+#[test]
+fn no_intents_gives_neutral_follow_through() {
+    let rep = PeerReputation::new("peer1".to_string());
+    // intent_count == 0 → follow_through = 1.0 (neutral)
+    let score = rep.composite_score();
+    assert!(score >= WEIGHT_FOLLOW_THROUGH - 0.01);
+}
+
+#[test]
+fn recency_score_decays_over_time() {
+    let mut rep = PeerReputation::new("peer1".to_string());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    // Just active
+    rep.last_active = now;
+    let recent = rep.recency_score_at(now);
+    assert!((recent - 1.0).abs() < 0.01);
+
+    // 24 hours ago (one half-life)
+    rep.last_active = now - 86400;
+    let day_old = rep.recency_score_at(now);
+    assert!((day_old - 0.5).abs() < 0.01);
+
+    // 48 hours ago (two half-lives)
+    rep.last_active = now - 172800;
+    let two_days = rep.recency_score_at(now);
+    assert!((two_days - 0.25).abs() < 0.01);
+}
+
+#[test]
+fn recency_zero_when_never_active() {
+    let rep = PeerReputation::new("peer1".to_string());
+    assert_eq!(rep.recency_score(), 0.0);
+}
+
+#[test]
+fn trust_level_thresholds() {
+    assert_eq!(TrustLevel::from_score(0.0), TrustLevel::Unknown);
+    assert_eq!(TrustLevel::from_score(-0.1), TrustLevel::Unknown);
+    assert_eq!(TrustLevel::from_score(0.1), TrustLevel::Low);
+    assert_eq!(TrustLevel::from_score(0.3), TrustLevel::Low);
+    assert_eq!(TrustLevel::from_score(0.31), TrustLevel::Medium);
+    assert_eq!(TrustLevel::from_score(0.6), TrustLevel::Medium);
+    assert_eq!(TrustLevel::from_score(0.61), TrustLevel::High);
+    assert_eq!(TrustLevel::from_score(0.85), TrustLevel::High);
+    assert_eq!(TrustLevel::from_score(0.86), TrustLevel::Trusted);
+    assert_eq!(TrustLevel::from_score(1.0), TrustLevel::Trusted);
+}
+
+#[test]
+fn trust_level_display() {
+    assert_eq!(format!("{}", TrustLevel::Unknown), "Unknown");
+    assert_eq!(format!("{}", TrustLevel::Low), "Low");
+    assert_eq!(format!("{}", TrustLevel::Medium), "Medium");
+    assert_eq!(format!("{}", TrustLevel::High), "High");
+    assert_eq!(format!("{}", TrustLevel::Trusted), "Trusted");
+}
+
+#[test]
+fn reputation_store_record_swap() {
+    let store = ReputationStore::new();
+    store.record_swap("peer1");
+    store.record_swap("peer1");
+    store.record_swap("peer2");
+
+    let rep1 = store.get("peer1").unwrap();
+    assert_eq!(rep1.swap_count, 2);
+    assert!(rep1.last_active > 0);
+
+    let rep2 = store.get("peer2").unwrap();
+    assert_eq!(rep2.swap_count, 1);
+}
+
+#[test]
+fn reputation_store_record_intent() {
+    let store = ReputationStore::new();
+    store.record_intent("peer1");
+    store.record_intent("peer1");
+
+    let rep = store.get("peer1").unwrap();
+    assert_eq!(rep.intent_count, 2);
+    assert_eq!(rep.swap_count, 0);
+}
+
+#[test]
+fn reputation_store_set_identity() {
+    let store = ReputationStore::new();
+    store.set_identity_verified("peer1", true);
+
+    let rep = store.get("peer1").unwrap();
+    assert!(rep.identity_verified);
+
+    store.set_identity_verified("peer1", false);
+    let rep = store.get("peer1").unwrap();
+    assert!(!rep.identity_verified);
+}
+
+#[test]
+fn reputation_store_score_unknown_peer() {
+    let store = ReputationStore::new();
+    assert_eq!(store.score("nonexistent"), 0.0);
+    assert_eq!(store.trust_level("nonexistent"), TrustLevel::Unknown);
+}
+
+#[test]
+fn reputation_store_all() {
+    let store = ReputationStore::new();
+    store.record_swap("peer1");
+    store.record_swap("peer2");
+
+    let all = store.all();
+    assert_eq!(all.len(), 2);
+    assert!(all.contains_key("peer1"));
+    assert!(all.contains_key("peer2"));
+}
+
+#[test]
+fn reputation_store_summary_with_data() {
+    let store = ReputationStore::new();
+    store.record_swap("peer1");
+    store.record_intent("peer1");
+    store.set_identity_verified("peer1", true);
+
+    let summary = store.summary("peer1");
+    assert!(summary.contains("Score:"));
+    assert!(summary.contains("Trust:"));
+    assert!(summary.contains("Swaps: 1"));
+    assert!(summary.contains("Intents: 1"));
+    assert!(summary.contains("verified"));
+}
+
+#[test]
+fn reputation_store_summary_no_data() {
+    let store = ReputationStore::new();
+    assert_eq!(store.summary("unknown"), "No reputation data");
+}
+
+#[test]
+fn reputation_store_thread_safe() {
+    let store = ReputationStore::new();
+    let store2 = store.clone();
+
+    store.record_swap("peer1");
+    // Clone shares the same Arc<Mutex<_>>
+    let rep = store2.get("peer1").unwrap();
+    assert_eq!(rep.swap_count, 1);
+}
+
+// --- Conditional swap tests ---
+
+#[test]
+fn empty_conditions_always_pass() {
+    let conditions = SwapConditions::default();
+    assert!(conditions.is_empty());
+    let store = ReputationStore::new();
+    assert!(conditions.evaluate("peer1", &store).is_passed());
+}
+
+#[test]
+fn min_reputation_passes_when_met() {
+    let store = ReputationStore::new();
+    // Build up reputation
+    for _ in 0..20 {
+        store.record_swap("peer1");
+    }
+    store.set_identity_verified("peer1", true);
+
+    let conditions = SwapConditions {
+        min_reputation: Some(0.2),
+        ..Default::default()
+    };
+    assert!(conditions.evaluate("peer1", &store).is_passed());
+}
+
+#[test]
+fn min_reputation_fails_when_too_low() {
+    let store = ReputationStore::new();
+    // No swaps, no identity → low score
+    let conditions = SwapConditions {
+        min_reputation: Some(0.9),
+        ..Default::default()
+    };
+    match conditions.evaluate("peer1", &store) {
+        ConditionResult::Failed(reason) => {
+            assert!(reason.contains("Reputation too low"));
+        }
+        ConditionResult::Passed => panic!("Should have failed"),
+    }
+}
+
+#[test]
+fn invalid_price_bound_fails() {
+    let store = ReputationStore::new();
+    let conditions = SwapConditions {
+        min_price: Some("not_a_number".to_string()),
+        ..Default::default()
+    };
+    match conditions.evaluate("peer1", &store) {
+        ConditionResult::Failed(reason) => {
+            assert!(reason.contains("Invalid min_price"));
+        }
+        ConditionResult::Passed => panic!("Should have failed"),
+    }
+}
+
+#[test]
+fn valid_price_bounds_pass() {
+    let store = ReputationStore::new();
+    let conditions = SwapConditions {
+        min_price: Some("0.95".to_string()),
+        max_price: Some("1.05".to_string()),
+        ..Default::default()
+    };
+    assert!(conditions.evaluate("peer1", &store).is_passed());
+}
+
+#[test]
+fn combined_conditions_all_checked() {
+    let store = ReputationStore::new();
+    // Fails on reputation (no data, score ~0)
+    let conditions = SwapConditions {
+        min_reputation: Some(0.5),
+        min_price: Some("0.95".to_string()),
+        max_price: Some("1.05".to_string()),
+    };
+    assert!(!conditions.evaluate("peer1", &store).is_passed());
+
+    // Now build reputation
+    for _ in 0..25 {
+        store.record_swap("peer1");
+    }
+    store.set_identity_verified("peer1", true);
+    // Should pass now
+    assert!(conditions.evaluate("peer1", &store).is_passed());
+}
+
+#[test]
+fn peer_reputation_serialization_roundtrip() {
+    let mut rep = PeerReputation::new("peer1".to_string());
+    rep.swap_count = 5;
+    rep.intent_count = 3;
+    rep.identity_verified = true;
+    rep.last_active = 1700000000;
+
+    let json = serde_json::to_string(&rep).unwrap();
+    let parsed: PeerReputation = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.peer_id, "peer1");
+    assert_eq!(parsed.swap_count, 5);
+    assert_eq!(parsed.intent_count, 3);
+    assert!(parsed.identity_verified);
+    assert_eq!(parsed.last_active, 1700000000);
+}


### PR DESCRIPTION
Closes #25, #26, #27

- Reputation scoring with composite score per peer (swap count, identity, follow-through, recency)
- Gossipsub peer scoring with P5 application score integration
- Conditional swaps via `cswap` command with `--min-rep`, `--min-price`, `--max-price`
- New CLI commands: `reputation`/`rep`, `cswap`
- `peers` now shows trust levels and scores

Tests: 46 → 73

## Summary by Sourcery

Introduce a reputation and trust system for peers and integrate it into gossip scoring and conditional swap execution.

New Features:
- Add a per-peer reputation model with composite scoring, trust levels, and a shared ReputationStore.
- Expose reputation data via new CLI commands `reputation`/`rep` and augment `peers` output with trust and score information.
- Add conditional swap support via a `cswap` CLI command with optional reputation and price constraints before executing swaps.
- Enable gossipsub peer scoring with application-specific scores derived from the reputation system.

Tests:
- Add a comprehensive reputation test suite covering scoring, trust tiers, conditional swap evaluation, serialization, and store behavior, increasing total tests from 46 to 73.