### PR TITLE
feat: request-response quotes protocol

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod coordination;
 mod identity;
 mod network;
+mod quotes;
 mod reputation;
 mod sim;
 mod uniswap;
@@ -27,6 +28,7 @@ use cli::Cli;
 use coordination::CoordinationBook;
 use identity::{IdentityBinding, PeerRegistry};
 use network::{AgentBehaviourEvent, AgentMessage, INTENT_TOPIC, TOPIC};
+use quotes::QuoteBook;
 use reputation::ReputationStore;
 use sim::SimulationMode;
 use uniswap::SwapClient;
@@ -112,6 +114,7 @@ async fn main() -> Result<()> {
     // Record own identity so the local agent's reputation reflects its verified status
     reputation_store.set_identity_verified(&peer_id_str, true);
     let coordination_book = CoordinationBook::new();
+    let quote_book = QuoteBook::new();
 
     // Dial a remote peer if provided as CLI argument
     if let Some(addr) = cli.dial {
@@ -140,7 +143,7 @@ async fn main() -> Result<()> {
             loop {
                 tokio::select! {
                     event = swarm.select_next_some() => {
-                        handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book);
+                        handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book, &quote_book);
                     }
                     _ = &mut flush_deadline => break,
                 }
@@ -178,14 +181,14 @@ async fn main() -> Result<()> {
         tokio::select! {
             line = stdin.next_line() => {
                 if let Ok(Some(line)) = line {
-                    pending_swap = handle_input(&line, &topic, &intent_topic, &mut swarm, &swap_client, &peer_registry, &sim_mode, &archiver, &reputation_store, &coordination_book).await;
+                    pending_swap = handle_input(&line, &topic, &intent_topic, &mut swarm, &swap_client, &peer_registry, &sim_mode, &archiver, &reputation_store, &coordination_book, &quote_book).await;
                 }
             }
             event = swarm.select_next_some() => {
-                handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book);
+                handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book, &quote_book);
             }
             _ = score_refresh_interval.tick() => {
-                refresh_peer_scores(&mut swarm, &reputation_store, &coordination_book);
+                refresh_peer_scores(&mut swarm, &reputation_store, &coordination_book, &quote_book);
             }
         }
     }
@@ -215,6 +218,7 @@ async fn handle_input(
     archiver: &LogArchiver,
     reputation_store: &ReputationStore,
     coordination_book: &CoordinationBook,
+    quote_book: &QuoteBook,
 ) -> Option<PendingSwap> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
@@ -240,6 +244,10 @@ async fn handle_input(
             println!("  propose <amt> <a2b|b2a> <desired_amt> [--min-rep <score>] - Propose coordinated swap");
             println!("  accept <proposal-id>  - Accept a swap proposal");
             println!("  proposals           - List active proposals");
+            println!("  quote <amt> <a2b|b2a> [--min-rep <score>] - Request a quote from peers");
+            println!("  respond <quote-id> <offered_amt> <price> - Respond to a quote request");
+            println!("  accept-quote <quote-id> [response-id] - Accept best/specific quote");
+            println!("  quotes              - List active quote requests");
             println!("  reputation [peer]   - Show reputation scores");
             println!("  sim on|off|local    - Set execution mode (sim/live/local-anvil)");
             println!("  archive             - Flush log buffer to Filecoin via sidecar");
@@ -739,6 +747,297 @@ async fn handle_input(
                 }
             }
         }
+        "quote" => {
+            if let Some(args) = parts.get(1) {
+                let tokens: Vec<&str> = args.split_whitespace().collect();
+                if tokens.len() < 2 {
+                    println!("Usage: quote <amount> <a2b|b2a> [--min-rep <score>]");
+                    return None;
+                }
+                let amount = tokens[0];
+                let direction = match tokens[1] {
+                    "a2b" => "TKNA -> TKNB",
+                    "b2a" => "TKNB -> TKNA",
+                    other => {
+                        println!("Invalid direction '{other}'. Use a2b or b2a.");
+                        return None;
+                    }
+                };
+
+                let mut min_reputation = None;
+                let mut i = 2;
+                while i < tokens.len() {
+                    if tokens[i] == "--min-rep" {
+                        if let Some(val) = tokens.get(i + 1) {
+                            min_reputation = val.parse().ok();
+                        }
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+
+                let peer_id_str = swarm.local_peer_id().to_string();
+                let quote_id = quotes::generate_quote_id(&peer_id_str);
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+
+                let request = quotes::QuoteRequest {
+                    quote_id: quote_id.clone(),
+                    requester: peer_id_str,
+                    direction: direction.to_string(),
+                    amount: amount.to_string(),
+                    min_reputation,
+                    expires_at: now + quotes::QUOTE_EXPIRY_SECS,
+                };
+
+                quote_book.add_request(request);
+
+                let msg = AgentMessage::QuoteRequest {
+                    quote_id: quote_id.clone(),
+                    requester: swarm.local_peer_id().to_string(),
+                    direction: direction.to_string(),
+                    amount: amount.to_string(),
+                    min_reputation,
+                    expires_at: now + quotes::QUOTE_EXPIRY_SECS,
+                };
+                publish_message(swarm, topic, &msg);
+
+                let rep_str = min_reputation
+                    .map(|r| format!(" (min-rep: {r:.2})"))
+                    .unwrap_or_default();
+                println!("[QUOTE] {quote_id}: Requesting quote for {amount} {direction}{rep_str}");
+            } else {
+                println!("Usage: quote <amount> <a2b|b2a> [--min-rep <score>]");
+            }
+        }
+        "respond" => {
+            if let Some(args) = parts.get(1) {
+                let tokens: Vec<&str> = args.split_whitespace().collect();
+                if tokens.len() < 3 {
+                    println!("Usage: respond <quote-id> <offered_amount> <price>");
+                    return None;
+                }
+                let quote_id = tokens[0];
+                let offered_amount = tokens[1];
+                let price = tokens[2];
+
+                match quote_book.get(quote_id) {
+                    Some((request, status, _)) => {
+                        if request.is_expired() {
+                            println!("[RESPOND] Quote {quote_id} has expired.");
+                            return None;
+                        }
+                        if matches!(status, quotes::QuoteStatus::Accepted { .. } | quotes::QuoteStatus::Expired) {
+                            println!("[RESPOND] Quote {quote_id} is no longer open.");
+                            return None;
+                        }
+
+                        // Reputation gate: check our score meets request's min_reputation
+                        let my_peer_id = swarm.local_peer_id().to_string();
+                        if let Some(min_rep) = request.min_reputation {
+                            let my_score = reputation_store.score(&my_peer_id);
+                            if my_score < min_rep {
+                                println!(
+                                    "[RESPOND] Cannot respond: your reputation {:.2} < required {:.2}",
+                                    my_score, min_rep
+                                );
+                                return None;
+                            }
+                        }
+
+                        let response_id = quotes::generate_response_id(&my_peer_id);
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
+
+                        let response = quotes::QuoteResponse {
+                            response_id: response_id.clone(),
+                            quote_id: quote_id.to_string(),
+                            responder: my_peer_id,
+                            offered_amount: offered_amount.to_string(),
+                            price: price.to_string(),
+                            expires_at: now + quotes::QUOTE_EXPIRY_SECS,
+                        };
+
+                        quote_book.add_response(response);
+
+                        let msg = AgentMessage::QuoteResponse {
+                            response_id: response_id.clone(),
+                            quote_id: quote_id.to_string(),
+                            responder: swarm.local_peer_id().to_string(),
+                            offered_amount: offered_amount.to_string(),
+                            price: price.to_string(),
+                            expires_at: now + quotes::QUOTE_EXPIRY_SECS,
+                        };
+                        publish_message(swarm, topic, &msg);
+                        println!("[RESPOND] Sent quote {response_id} for {quote_id}: {offered_amount} at price {price}");
+                    }
+                    None => {
+                        println!("[RESPOND] Quote {quote_id} not found.");
+                    }
+                }
+            } else {
+                println!("Usage: respond <quote-id> <offered_amount> <price>");
+            }
+        }
+        "accept-quote" => {
+            if let Some(args) = parts.get(1) {
+                let tokens: Vec<&str> = args.split_whitespace().collect();
+                if tokens.is_empty() {
+                    println!("Usage: accept-quote <quote-id> [response-id]");
+                    return None;
+                }
+                let quote_id = tokens[0];
+                let specific_response_id = tokens.get(1).map(|s| s.to_string());
+
+                match quote_book.get(quote_id) {
+                    Some((request, status, responses)) => {
+                        if request.is_expired() {
+                            println!("[ACCEPT-QUOTE] Quote {quote_id} has expired.");
+                            return None;
+                        }
+                        if matches!(status, quotes::QuoteStatus::Accepted { .. }) {
+                            println!("[ACCEPT-QUOTE] Quote {quote_id} already accepted.");
+                            return None;
+                        }
+                        if responses.is_empty() {
+                            println!("[ACCEPT-QUOTE] No responses for {quote_id} yet.");
+                            return None;
+                        }
+
+                        // Select specific response or best response
+                        let selected = if let Some(ref rid) = specific_response_id {
+                            responses.iter().find(|r| r.response_id == *rid).cloned()
+                        } else {
+                            quote_book.best_response(quote_id)
+                        };
+
+                        let response = match selected {
+                            Some(r) => r,
+                            None => {
+                                println!("[ACCEPT-QUOTE] Response not found or all expired.");
+                                return None;
+                            }
+                        };
+
+                        if response.is_expired() {
+                            println!("[ACCEPT-QUOTE] Selected response has expired.");
+                            return None;
+                        }
+
+                        // Reputation gate: check responder's trust level
+                        let responder_trust = reputation_store.trust_level(&response.responder);
+                        if matches!(responder_trust, reputation::TrustLevel::Unknown) {
+                            println!("[ACCEPT-QUOTE] Responder is untrusted.");
+                            return None;
+                        }
+
+                        quote_book.update_status(
+                            quote_id,
+                            quotes::QuoteStatus::Accepted {
+                                response_id: response.response_id.clone(),
+                                responder: response.responder.clone(),
+                            },
+                        );
+
+                        let msg = AgentMessage::QuoteAccept {
+                            quote_id: quote_id.to_string(),
+                            response_id: response.response_id.clone(),
+                            acceptor: swarm.local_peer_id().to_string(),
+                        };
+                        publish_message(swarm, topic, &msg);
+
+                        let responder_short =
+                            &response.responder[..8.min(response.responder.len())];
+                        println!(
+                            "[ACCEPT-QUOTE] Accepted {} from {responder_short}: {} at price {}",
+                            response.response_id, response.offered_amount, response.price
+                        );
+
+                        // Broadcast intent and trigger swap execution
+                        let zero_for_one = request.direction.contains("TKNA -> TKNB");
+                        let intent_msg = AgentMessage::SwapIntent {
+                            agent: swarm.local_peer_id().to_string(),
+                            direction: request.direction.clone(),
+                            amount: request.amount.clone(),
+                            min_price: None,
+                            max_price: None,
+                            timestamp: std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs(),
+                        };
+                        publish_message(swarm, intent_topic, &intent_msg);
+                        reputation_store.record_intent(&swarm.local_peer_id().to_string());
+
+                        return Some(PendingSwap {
+                            is_v2: false,
+                            zero_for_one,
+                            amount_str: request.amount.clone(),
+                            direction: request.direction.clone(),
+                            version: "V1".to_string(),
+                            conditions: reputation::SwapConditions::default(),
+                            proposal_id: None,
+                        });
+                    }
+                    None => {
+                        println!("[ACCEPT-QUOTE] Quote {quote_id} not found.");
+                    }
+                }
+            } else {
+                println!("Usage: accept-quote <quote-id> [response-id]");
+            }
+        }
+        "quotes" => {
+            quote_book.cleanup_expired_with_requesters();
+            let active = quote_book.active_quotes();
+            if active.is_empty() {
+                println!("No active quote requests.");
+            } else {
+                println!("Active quote requests ({}):", active.len());
+                for (request, status, responses) in &active {
+                    let status_str = match status {
+                        quotes::QuoteStatus::Open => "open".to_string(),
+                        quotes::QuoteStatus::Responded => {
+                            format!("{} response(s)", responses.len())
+                        }
+                        quotes::QuoteStatus::Accepted {
+                            response_id,
+                            responder,
+                        } => {
+                            format!(
+                                "accepted {} from {}",
+                                response_id,
+                                &responder[..8.min(responder.len())]
+                            )
+                        }
+                        quotes::QuoteStatus::Expired => "expired".to_string(),
+                    };
+                    let requester_short =
+                        &request.requester[..8.min(request.requester.len())];
+                    println!(
+                        "  {} | {} {} | by {} | {}",
+                        request.quote_id,
+                        request.amount,
+                        request.direction,
+                        requester_short,
+                        status_str
+                    );
+                    for resp in responses {
+                        let resp_short =
+                            &resp.responder[..8.min(resp.responder.len())];
+                        println!(
+                            "    -> {} | {} offers {} at price {}",
+                            resp.response_id, resp_short, resp.offered_amount, resp.price
+                        );
+                    }
+                }
+            }
+        }
         _ => {
             let msg = AgentMessage::Chat {
                 content: trimmed.to_string(),
@@ -884,6 +1183,7 @@ fn handle_swarm_event(
     archiver: &LogArchiver,
     reputation_store: &ReputationStore,
     coordination_book: &CoordinationBook,
+    quote_book: &QuoteBook,
 ) {
     match event {
         SwarmEvent::Behaviour(AgentBehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
@@ -1140,6 +1440,119 @@ fn handle_swarm_event(
                             }
                         }
                     }
+                    AgentMessage::QuoteRequest {
+                        quote_id,
+                        requester,
+                        direction,
+                        amount,
+                        min_reputation,
+                        expires_at,
+                    } => {
+                        if requester != swarm.local_peer_id().to_string() {
+                            // Gate: ignore requests from unknown peers
+                            let requester_trust = reputation_store.trust_level(&requester);
+                            if matches!(requester_trust, reputation::TrustLevel::Unknown) {
+                                println!(
+                                    "[QUOTE-REQ] Ignored from untrusted peer {}",
+                                    &requester[..8.min(requester.len())]
+                                );
+                                return;
+                            }
+                            let rep_str = min_reputation
+                                .map(|r| format!(" (min-rep: {r:.2})"))
+                                .unwrap_or_default();
+                            let requester_short = &requester[..8.min(requester.len())];
+                            println!(
+                                "[QUOTE-REQ] {quote_id}: {requester_short} wants {amount} {direction}{rep_str}"
+                            );
+                            println!("  Type 'respond {quote_id} <offered_amount> <price>' to respond.");
+
+                            let request = quotes::QuoteRequest {
+                                quote_id,
+                                requester,
+                                direction,
+                                amount,
+                                min_reputation,
+                                expires_at,
+                            };
+                            quote_book.add_request(request);
+                        }
+                    }
+                    AgentMessage::QuoteResponse {
+                        response_id,
+                        quote_id,
+                        responder,
+                        offered_amount,
+                        price,
+                        expires_at,
+                    } => {
+                        if responder != swarm.local_peer_id().to_string() {
+                            // Gate: ignore responses from unknown peers
+                            let responder_trust = reputation_store.trust_level(&responder);
+                            if matches!(responder_trust, reputation::TrustLevel::Unknown) {
+                                println!(
+                                    "[QUOTE-RESP] Ignored from untrusted peer {}",
+                                    &responder[..8.min(responder.len())]
+                                );
+                                return;
+                            }
+
+                            let response = quotes::QuoteResponse {
+                                response_id: response_id.clone(),
+                                quote_id: quote_id.clone(),
+                                responder: responder.clone(),
+                                offered_amount: offered_amount.clone(),
+                                price: price.clone(),
+                                expires_at,
+                            };
+                            quote_book.add_response(response);
+
+                            let responder_short = &responder[..8.min(responder.len())];
+                            println!(
+                                "[QUOTE-RESP] {response_id} for {quote_id}: {responder_short} offers {offered_amount} at price {price}"
+                            );
+
+                            // Hint the requester to accept
+                            if let Some((req, _, _)) = quote_book.get(&quote_id) {
+                                if req.requester == swarm.local_peer_id().to_string() {
+                                    println!("  Type 'accept-quote {quote_id}' to accept best quote, or 'accept-quote {quote_id} {response_id}' for this one.");
+                                }
+                            }
+                        }
+                    }
+                    AgentMessage::QuoteAccept {
+                        quote_id,
+                        response_id,
+                        acceptor,
+                    } => {
+                        if acceptor != swarm.local_peer_id().to_string() {
+                            let acceptor_short = &acceptor[..8.min(acceptor.len())];
+                            println!(
+                                "[QUOTE-ACCEPTED] {acceptor_short} accepted response {response_id} for {quote_id}"
+                            );
+
+                            // Check if our response was accepted
+                            if let Some((_, _, responses)) = quote_book.get(&quote_id) {
+                                for resp in &responses {
+                                    if resp.response_id == response_id
+                                        && resp.responder == swarm.local_peer_id().to_string()
+                                    {
+                                        println!(
+                                            "[COORD] Your quote was accepted! Execute your side of the swap."
+                                        );
+                                    }
+                                }
+                            }
+
+                            quote_book.update_status(
+                                &quote_id,
+                                quotes::QuoteStatus::Accepted {
+                                    response_id,
+                                    responder: acceptor,
+                                },
+                            );
+                        }
+                    }
                 }
             } else {
                 // Invalid/malformed message — reject for P4 scoring
@@ -1185,11 +1598,18 @@ fn refresh_peer_scores(
     swarm: &mut libp2p::Swarm<network::AgentBehaviour>,
     reputation_store: &ReputationStore,
     coordination_book: &CoordinationBook,
+    quote_book: &QuoteBook,
 ) {
     // Penalize initiators of newly expired proposals
     let expired_initiators = coordination_book.cleanup_expired_with_initiators();
     for initiator in &expired_initiators {
         reputation_store.record_expired_proposal(initiator);
+    }
+
+    // Penalize requesters of newly expired quotes
+    let expired_requesters = quote_book.cleanup_expired_with_requesters();
+    for requester in &expired_requesters {
+        reputation_store.record_expired_proposal(requester);
     }
 
     // Refresh P5 scores for all peers (decay-aware via composite_score())

--- a/agent/src/network.rs
+++ b/agent/src/network.rs
@@ -69,6 +69,30 @@ pub enum AgentMessage {
         executor: String,
         tx_hash: String,
     },
+    /// Request a quote from peers for a swap
+    QuoteRequest {
+        quote_id: String,
+        requester: String,
+        direction: String,
+        amount: String,
+        min_reputation: Option<f64>,
+        expires_at: u64,
+    },
+    /// Respond to a quote request with terms
+    QuoteResponse {
+        response_id: String,
+        quote_id: String,
+        responder: String,
+        offered_amount: String,
+        price: String,
+        expires_at: u64,
+    },
+    /// Accept a specific quote response (triggers execution)
+    QuoteAccept {
+        quote_id: String,
+        response_id: String,
+        acceptor: String,
+    },
 }
 
 /// Build gossipsub peer scoring parameters tuned for swap agent network.

--- a/agent/src/quotes.rs
+++ b/agent/src/quotes.rs
@@ -1,0 +1,207 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Default quote expiry in seconds (30s).
+pub const QUOTE_EXPIRY_SECS: u64 = 30;
+
+/// Generate a short quote request ID from peer_id and timestamp.
+pub fn generate_quote_id(peer_id: &str) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let suffix = &peer_id[peer_id.len().saturating_sub(6)..];
+    format!("quote_{suffix}_{now:x}")
+}
+
+/// Generate a short quote response ID from peer_id and timestamp.
+pub fn generate_response_id(peer_id: &str) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let suffix = &peer_id[peer_id.len().saturating_sub(6)..];
+    format!("resp_{suffix}_{now:x}")
+}
+
+/// A quote request broadcast by an agent seeking price quotes from peers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuoteRequest {
+    pub quote_id: String,
+    pub requester: String,
+    pub direction: String,
+    pub amount: String,
+    pub min_reputation: Option<f64>,
+    pub expires_at: u64,
+}
+
+impl QuoteRequest {
+    pub fn is_expired(&self) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        now > self.expires_at
+    }
+}
+
+/// A quote response from a peer offering terms for a requested swap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuoteResponse {
+    pub response_id: String,
+    pub quote_id: String,
+    pub responder: String,
+    pub offered_amount: String,
+    pub price: String,
+    pub expires_at: u64,
+}
+
+impl QuoteResponse {
+    pub fn is_expired(&self) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        now > self.expires_at
+    }
+}
+
+/// Status of a quote request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum QuoteStatus {
+    /// Waiting for responses from peers.
+    Open,
+    /// At least one response received; requester is evaluating.
+    Responded,
+    /// Requester accepted a specific response.
+    Accepted {
+        response_id: String,
+        responder: String,
+    },
+    /// Quote request expired without acceptance.
+    Expired,
+}
+
+type QuoteEntry = (QuoteRequest, QuoteStatus, Vec<QuoteResponse>);
+
+/// Tracks active quote requests, their status, and collected responses.
+#[derive(Clone, Debug)]
+pub struct QuoteBook {
+    quotes: Arc<Mutex<HashMap<String, QuoteEntry>>>,
+}
+
+impl QuoteBook {
+    pub fn new() -> Self {
+        Self {
+            quotes: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Add a new quote request.
+    pub fn add_request(&self, request: QuoteRequest) {
+        let id = request.quote_id.clone();
+        let mut book = self.quotes.lock().unwrap();
+        book.insert(id, (request, QuoteStatus::Open, Vec::new()));
+    }
+
+    /// Get a quote request by ID.
+    pub fn get(&self, quote_id: &str) -> Option<QuoteEntry> {
+        self.quotes.lock().unwrap().get(quote_id).cloned()
+    }
+
+    /// Add a response to an existing quote request.
+    /// Returns true if the quote existed and the response was added.
+    pub fn add_response(&self, response: QuoteResponse) -> bool {
+        let mut book = self.quotes.lock().unwrap();
+        if let Some(entry) = book.get_mut(&response.quote_id) {
+            entry.2.push(response);
+            if entry.1 == QuoteStatus::Open {
+                entry.1 = QuoteStatus::Responded;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Update the status of a quote request.
+    pub fn update_status(&self, quote_id: &str, status: QuoteStatus) -> bool {
+        let mut book = self.quotes.lock().unwrap();
+        if let Some(entry) = book.get_mut(quote_id) {
+            entry.1 = status;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get all active (non-expired) quote requests.
+    pub fn active_quotes(&self) -> Vec<QuoteEntry> {
+        let book = self.quotes.lock().unwrap();
+        book.values()
+            .filter(|(req, status, _)| !req.is_expired() && *status != QuoteStatus::Expired)
+            .cloned()
+            .collect()
+    }
+
+    /// Get all responses for a specific quote request.
+    #[cfg(test)]
+    pub fn responses_for(&self, quote_id: &str) -> Vec<QuoteResponse> {
+        self.quotes
+            .lock()
+            .unwrap()
+            .get(quote_id)
+            .map(|(_, _, responses)| responses.clone())
+            .unwrap_or_default()
+    }
+
+    /// Select the best response for a quote (highest offered_amount).
+    pub fn best_response(&self, quote_id: &str) -> Option<QuoteResponse> {
+        let book = self.quotes.lock().unwrap();
+        book.get(quote_id).and_then(|(_, _, responses)| {
+            responses
+                .iter()
+                .filter(|r| !r.is_expired())
+                .max_by(|a, b| {
+                    let a_val: f64 = a.offered_amount.parse().unwrap_or(0.0);
+                    let b_val: f64 = b.offered_amount.parse().unwrap_or(0.0);
+                    a_val.partial_cmp(&b_val).unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .cloned()
+        })
+    }
+
+    /// Clean up expired quotes and return requester peer IDs of newly expired ones.
+    /// Only catches quotes transitioning to Expired for the first time,
+    /// preventing double-counting for penalty tracking.
+    pub fn cleanup_expired_with_requesters(&self) -> Vec<String> {
+        let mut book = self.quotes.lock().unwrap();
+        let newly_expired: Vec<(String, String)> = book
+            .iter()
+            .filter(|(_, (req, status, _))| req.is_expired() && *status != QuoteStatus::Expired)
+            .map(|(id, (req, _, _))| (id.clone(), req.requester.clone()))
+            .collect();
+        let requesters: Vec<String> = newly_expired.iter().map(|(_, r)| r.clone()).collect();
+        for (id, _) in &newly_expired {
+            if let Some(entry) = book.get_mut(id) {
+                entry.1 = QuoteStatus::Expired;
+            }
+        }
+        requesters
+    }
+
+    /// Get all quotes (including expired).
+    #[cfg(test)]
+    pub fn all(&self) -> HashMap<String, QuoteEntry> {
+        self.quotes.lock().unwrap().clone()
+    }
+
+    /// Count of active quotes.
+    #[cfg(test)]
+    pub fn active_count(&self) -> usize {
+        self.active_quotes().len()
+    }
+}

--- a/agent/src/tests/mod.rs
+++ b/agent/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod archival;
 mod coordination;
 mod identity;
 mod network;
+mod quotes;
 mod reputation;
 mod sim;
 mod uniswap;

--- a/agent/src/tests/network.rs
+++ b/agent/src/tests/network.rs
@@ -162,6 +162,148 @@ fn swap_intent_serialized_json_has_type_tag() {
     assert_eq!(intent["type"], "SwapIntent");
 }
 
+// --- Quote message roundtrip tests ---
+
+#[test]
+fn quote_request_roundtrip() {
+    let msg = AgentMessage::QuoteRequest {
+        quote_id: "quote_abc_123".into(),
+        requester: "peer1".into(),
+        direction: "TKNA -> TKNB".into(),
+        amount: "100".into(),
+        min_reputation: Some(0.5),
+        expires_at: 1700000000,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::QuoteRequest {
+            quote_id,
+            requester,
+            direction,
+            amount,
+            min_reputation,
+            expires_at,
+        } => {
+            assert_eq!(quote_id, "quote_abc_123");
+            assert_eq!(requester, "peer1");
+            assert_eq!(direction, "TKNA -> TKNB");
+            assert_eq!(amount, "100");
+            assert_eq!(min_reputation, Some(0.5));
+            assert_eq!(expires_at, 1700000000);
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn quote_request_optional_min_reputation_none() {
+    let msg = AgentMessage::QuoteRequest {
+        quote_id: "q1".into(),
+        requester: "peer1".into(),
+        direction: "TKNA -> TKNB".into(),
+        amount: "50".into(),
+        min_reputation: None,
+        expires_at: 1700000000,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::QuoteRequest { min_reputation, .. } => {
+            assert!(min_reputation.is_none());
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn quote_response_roundtrip() {
+    let msg = AgentMessage::QuoteResponse {
+        response_id: "resp_xyz_456".into(),
+        quote_id: "quote_abc_123".into(),
+        responder: "peer2".into(),
+        offered_amount: "98".into(),
+        price: "0.98".into(),
+        expires_at: 1700000030,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::QuoteResponse {
+            response_id,
+            quote_id,
+            responder,
+            offered_amount,
+            price,
+            expires_at,
+        } => {
+            assert_eq!(response_id, "resp_xyz_456");
+            assert_eq!(quote_id, "quote_abc_123");
+            assert_eq!(responder, "peer2");
+            assert_eq!(offered_amount, "98");
+            assert_eq!(price, "0.98");
+            assert_eq!(expires_at, 1700000030);
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn quote_accept_roundtrip() {
+    let msg = AgentMessage::QuoteAccept {
+        quote_id: "quote_abc_123".into(),
+        response_id: "resp_xyz_456".into(),
+        acceptor: "peer1".into(),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::QuoteAccept {
+            quote_id,
+            response_id,
+            acceptor,
+        } => {
+            assert_eq!(quote_id, "quote_abc_123");
+            assert_eq!(response_id, "resp_xyz_456");
+            assert_eq!(acceptor, "peer1");
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn quote_messages_serialized_json_has_type_tags() {
+    let qr = serde_json::to_value(&AgentMessage::QuoteRequest {
+        quote_id: "q".into(),
+        requester: "p".into(),
+        direction: "d".into(),
+        amount: "1".into(),
+        min_reputation: None,
+        expires_at: 0,
+    })
+    .unwrap();
+    assert_eq!(qr["type"], "QuoteRequest");
+
+    let qresp = serde_json::to_value(&AgentMessage::QuoteResponse {
+        response_id: "r".into(),
+        quote_id: "q".into(),
+        responder: "p".into(),
+        offered_amount: "1".into(),
+        price: "1".into(),
+        expires_at: 0,
+    })
+    .unwrap();
+    assert_eq!(qresp["type"], "QuoteResponse");
+
+    let qa = serde_json::to_value(&AgentMessage::QuoteAccept {
+        quote_id: "q".into(),
+        response_id: "r".into(),
+        acceptor: "p".into(),
+    })
+    .unwrap();
+    assert_eq!(qa["type"], "QuoteAccept");
+}
+
 // --- Peer score parameter tests ---
 
 #[test]

--- a/agent/src/tests/quotes.rs
+++ b/agent/src/tests/quotes.rs
@@ -1,0 +1,357 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::quotes::{
+    generate_quote_id, generate_response_id, QuoteBook, QuoteRequest, QuoteResponse, QuoteStatus,
+    QUOTE_EXPIRY_SECS,
+};
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn sample_request(id: &str, expires_at: u64) -> QuoteRequest {
+    QuoteRequest {
+        quote_id: id.to_string(),
+        requester: "peer_abc123".to_string(),
+        direction: "TKNA -> TKNB".to_string(),
+        amount: "100".to_string(),
+        min_reputation: None,
+        expires_at,
+    }
+}
+
+fn sample_response(response_id: &str, quote_id: &str, offered_amount: &str) -> QuoteResponse {
+    QuoteResponse {
+        response_id: response_id.to_string(),
+        quote_id: quote_id.to_string(),
+        responder: "peer_xyz789".to_string(),
+        offered_amount: offered_amount.to_string(),
+        price: "0.98".to_string(),
+        expires_at: now_secs() + 60,
+    }
+}
+
+// --- ID generation ---
+
+#[test]
+fn generate_quote_id_format() {
+    let id = generate_quote_id("12D3KooWABC123");
+    assert!(id.starts_with("quote_"));
+    assert!(id.len() > 10);
+}
+
+#[test]
+fn generate_response_id_format() {
+    let id = generate_response_id("12D3KooWABC123");
+    assert!(id.starts_with("resp_"));
+    assert!(id.len() > 10);
+}
+
+// --- QuoteRequest expiry ---
+
+#[test]
+fn request_not_expired_when_fresh() {
+    let r = sample_request("q1", now_secs() + 60);
+    assert!(!r.is_expired());
+}
+
+#[test]
+fn request_expired_when_past() {
+    let r = sample_request("q1", now_secs() - 1);
+    assert!(r.is_expired());
+}
+
+// --- QuoteResponse expiry ---
+
+#[test]
+fn response_not_expired_when_fresh() {
+    let r = sample_response("r1", "q1", "98");
+    assert!(!r.is_expired());
+}
+
+#[test]
+fn response_expired_when_past() {
+    let r = QuoteResponse {
+        response_id: "r1".to_string(),
+        quote_id: "q1".to_string(),
+        responder: "peer_xyz".to_string(),
+        offered_amount: "98".to_string(),
+        price: "0.98".to_string(),
+        expires_at: now_secs() - 1,
+    };
+    assert!(r.is_expired());
+}
+
+// --- QuoteBook CRUD ---
+
+#[test]
+fn book_add_and_get() {
+    let book = QuoteBook::new();
+    let r = sample_request("q1", now_secs() + 60);
+    book.add_request(r);
+
+    let (request, status, responses) = book.get("q1").unwrap();
+    assert_eq!(request.quote_id, "q1");
+    assert_eq!(status, QuoteStatus::Open);
+    assert!(responses.is_empty());
+}
+
+#[test]
+fn book_get_missing_returns_none() {
+    let book = QuoteBook::new();
+    assert!(book.get("nonexistent").is_none());
+}
+
+#[test]
+fn book_add_response() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+
+    let resp = sample_response("r1", "q1", "98");
+    assert!(book.add_response(resp));
+
+    let (_, _, responses) = book.get("q1").unwrap();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].response_id, "r1");
+}
+
+#[test]
+fn book_add_response_to_missing_returns_false() {
+    let book = QuoteBook::new();
+    let resp = sample_response("r1", "nonexistent", "98");
+    assert!(!book.add_response(resp));
+}
+
+#[test]
+fn book_add_response_transitions_to_responded() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+
+    let (_, status, _) = book.get("q1").unwrap();
+    assert_eq!(status, QuoteStatus::Open);
+
+    book.add_response(sample_response("r1", "q1", "98"));
+
+    let (_, status, _) = book.get("q1").unwrap();
+    assert_eq!(status, QuoteStatus::Responded);
+}
+
+#[test]
+fn book_add_multiple_responses_stays_responded() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+
+    book.add_response(sample_response("r1", "q1", "98"));
+    book.add_response(sample_response("r2", "q1", "97"));
+
+    let (_, status, responses) = book.get("q1").unwrap();
+    assert_eq!(status, QuoteStatus::Responded);
+    assert_eq!(responses.len(), 2);
+}
+
+// --- Status transitions ---
+
+#[test]
+fn book_update_status() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+
+    let updated = book.update_status(
+        "q1",
+        QuoteStatus::Accepted {
+            response_id: "r1".to_string(),
+            responder: "peer_xyz".to_string(),
+        },
+    );
+    assert!(updated);
+
+    let (_, status, _) = book.get("q1").unwrap();
+    assert_eq!(
+        status,
+        QuoteStatus::Accepted {
+            response_id: "r1".to_string(),
+            responder: "peer_xyz".to_string(),
+        }
+    );
+}
+
+#[test]
+fn book_update_nonexistent_returns_false() {
+    let book = QuoteBook::new();
+    assert!(!book.update_status("nope", QuoteStatus::Expired));
+}
+
+#[test]
+fn full_quote_lifecycle() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("lifecycle", now_secs() + 60));
+
+    // Open → Responded (via add_response)
+    book.add_response(sample_response("r1", "lifecycle", "98"));
+    let (_, status, _) = book.get("lifecycle").unwrap();
+    assert_eq!(status, QuoteStatus::Responded);
+
+    // Responded → Accepted
+    book.update_status(
+        "lifecycle",
+        QuoteStatus::Accepted {
+            response_id: "r1".to_string(),
+            responder: "peer_xyz789".to_string(),
+        },
+    );
+
+    let (_, status, _) = book.get("lifecycle").unwrap();
+    assert_eq!(
+        status,
+        QuoteStatus::Accepted {
+            response_id: "r1".to_string(),
+            responder: "peer_xyz789".to_string(),
+        }
+    );
+}
+
+// --- Filtering and cleanup ---
+
+#[test]
+fn book_active_quotes_excludes_expired() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("active", now_secs() + 60));
+    book.add_request(sample_request("expired", now_secs() - 1));
+
+    let active = book.active_quotes();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].0.quote_id, "active");
+}
+
+#[test]
+fn book_active_quotes_excludes_expired_status() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+    book.update_status("q1", QuoteStatus::Expired);
+
+    let active = book.active_quotes();
+    assert_eq!(active.len(), 0);
+}
+
+#[test]
+fn book_cleanup_expired_with_requesters_returns_ids() {
+    let book = QuoteBook::new();
+    let mut r1 = sample_request("expired1", now_secs() - 1);
+    r1.requester = "peer_requester_a".to_string();
+    let mut r2 = sample_request("expired2", now_secs() - 1);
+    r2.requester = "peer_requester_b".to_string();
+    book.add_request(r1);
+    book.add_request(r2);
+    book.add_request(sample_request("active", now_secs() + 60));
+
+    let requesters = book.cleanup_expired_with_requesters();
+    assert_eq!(requesters.len(), 2);
+    assert!(requesters.contains(&"peer_requester_a".to_string()));
+    assert!(requesters.contains(&"peer_requester_b".to_string()));
+}
+
+#[test]
+fn book_cleanup_expired_with_requesters_no_double_count() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("expired1", now_secs() - 1));
+
+    let first = book.cleanup_expired_with_requesters();
+    assert_eq!(first.len(), 1);
+
+    // Second call should find none — already marked Expired
+    let second = book.cleanup_expired_with_requesters();
+    assert_eq!(second.len(), 0);
+}
+
+// --- Responses ---
+
+#[test]
+fn responses_for_returns_all() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+    book.add_response(sample_response("r1", "q1", "98"));
+    book.add_response(sample_response("r2", "q1", "97"));
+
+    let responses = book.responses_for("q1");
+    assert_eq!(responses.len(), 2);
+}
+
+#[test]
+fn responses_for_missing_returns_empty() {
+    let book = QuoteBook::new();
+    let responses = book.responses_for("nonexistent");
+    assert!(responses.is_empty());
+}
+
+// --- Best response ---
+
+#[test]
+fn best_response_selects_highest_offered_amount() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+    book.add_response(sample_response("r1", "q1", "95"));
+    book.add_response(sample_response("r2", "q1", "99"));
+    book.add_response(sample_response("r3", "q1", "97"));
+
+    let best = book.best_response("q1").unwrap();
+    assert_eq!(best.response_id, "r2");
+    assert_eq!(best.offered_amount, "99");
+}
+
+#[test]
+fn best_response_returns_none_for_missing() {
+    let book = QuoteBook::new();
+    assert!(book.best_response("nonexistent").is_none());
+}
+
+#[test]
+fn best_response_returns_none_when_no_responses() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+    assert!(book.best_response("q1").is_none());
+}
+
+// --- Thread safety ---
+
+#[test]
+fn book_thread_safe() {
+    let book = QuoteBook::new();
+    let book2 = book.clone();
+
+    book.add_request(sample_request("shared", now_secs() + 60));
+    // Clone shares the same Arc<Mutex<_>>
+    let result = book2.get("shared");
+    assert!(result.is_some());
+}
+
+// --- Constants ---
+
+#[test]
+fn quote_expiry_constant() {
+    assert_eq!(QUOTE_EXPIRY_SECS, 30);
+}
+
+// --- All and active_count ---
+
+#[test]
+fn book_all_returns_everything() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+    book.add_request(sample_request("q2", now_secs() - 1));
+
+    let all = book.all();
+    assert_eq!(all.len(), 2);
+}
+
+#[test]
+fn book_active_count() {
+    let book = QuoteBook::new();
+    book.add_request(sample_request("q1", now_secs() + 60));
+    book.add_request(sample_request("q2", now_secs() + 60));
+    book.add_request(sample_request("q3", now_secs() - 1));
+
+    assert_eq!(book.active_count(), 2);
+}


### PR DESCRIPTION
## Summary
- Add quote request/response negotiation layer for agents to request price quotes from peers before committing to swaps
- New `quotes.rs` module with `QuoteRequest`, `QuoteResponse`, `QuoteStatus`, `QuoteBook` (mirrors coordination pattern)
- Three new `AgentMessage` variants: `QuoteRequest`, `QuoteResponse`, `QuoteAccept`
- Quote lifecycle: `Open` → `Responded` → `Accepted` (or `Expired` after 30s)
- Best-quote selection (`best_response`) picks highest `offered_amount` among non-expired responses
- Reputation gating: requests/responses from `TrustLevel::Unknown` peers ignored, responders must meet `min_reputation`
- Expired quote penalty integrated into periodic `refresh_peer_scores()`
- CLI: `quote`, `respond`, `accept-quote`, `quotes`
- 33 new tests (142 total), 0 clippy warnings

## New Commands
| Command | Description |
|---------|-------------|
| `quote <amt> <a2b\|b2a> [--min-rep <score>]` | Request a quote from peers |
| `respond <quote-id> <offered_amt> <price>` | Respond to a quote request |
| `accept-quote <quote-id> [response-id]` | Accept best/specific quote (triggers swap) |
| `quotes` | List active quote requests + responses |

## Test plan
- [x] `cargo build` — clean compilation
- [x] `cargo clippy` — 0 warnings
- [x] `cargo test` — 142 tests pass (109 existing + 33 new)
- [ ] Manual: run two agents in `--simulate`, one issues `quote 100 a2b`, other responds, first accepts

closes #34 
## Summary by Sourcery

Introduce a request/response quote negotiation layer for swap agents, enabling peers to request, respond to, and accept price quotes before executing swaps.

New Features:
- Add QuoteRequest, QuoteResponse, QuoteAccept message types and a QuoteBook to track quote lifecycles and select best responses.
- Expose CLI commands for managing quotes: quote, respond, accept-quote, and quotes to request, answer, accept, and list quote negotiations.

Enhancements:
- Integrate quote handling into the main event loop, swarm event processing, and periodic reputation refresh, including penalties for expired quotes and trust-level gating for requests and responses.

Tests:
- Add serialization roundtrip and type-tag tests for new quote-related AgentMessage variants.
- Add a dedicated quotes test module covering ID generation, expiry behavior, QuoteBook CRUD and lifecycle, best-response selection, cleanup logic, and thread safety.