### PR TITLE
feat: MEV-aware coordination

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -2,6 +2,7 @@ mod archival;
 mod cli;
 mod coordination;
 mod identity;
+mod mev;
 mod network;
 mod quotes;
 mod reputation;
@@ -27,6 +28,7 @@ use archival::{LogArchiver, LogEntry};
 use cli::Cli;
 use coordination::CoordinationBook;
 use identity::{IdentityBinding, PeerRegistry};
+use mev::MevStore;
 use network::{AgentBehaviourEvent, AgentMessage, INTENT_TOPIC, TOPIC};
 use quotes::QuoteBook;
 use reputation::ReputationStore;
@@ -115,6 +117,7 @@ async fn main() -> Result<()> {
     reputation_store.set_identity_verified(&peer_id_str, true);
     let coordination_book = CoordinationBook::new();
     let quote_book = QuoteBook::new();
+    let mev_store = MevStore::new();
 
     // Dial a remote peer if provided as CLI argument
     if let Some(addr) = cli.dial {
@@ -143,7 +146,7 @@ async fn main() -> Result<()> {
             loop {
                 tokio::select! {
                     event = swarm.select_next_some() => {
-                        handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book, &quote_book);
+                        handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book, &quote_book, &mev_store);
                     }
                     _ = &mut flush_deadline => break,
                 }
@@ -173,6 +176,7 @@ async fn main() -> Result<()> {
                 &archiver,
                 &coordination_book,
                 &reputation_store,
+                &mev_store,
             )
             .await;
             continue;
@@ -181,11 +185,11 @@ async fn main() -> Result<()> {
         tokio::select! {
             line = stdin.next_line() => {
                 if let Ok(Some(line)) = line {
-                    pending_swap = handle_input(&line, &topic, &intent_topic, &mut swarm, &swap_client, &peer_registry, &sim_mode, &archiver, &reputation_store, &coordination_book, &quote_book).await;
+                    pending_swap = handle_input(&line, &topic, &intent_topic, &mut swarm, &swap_client, &peer_registry, &sim_mode, &archiver, &reputation_store, &coordination_book, &quote_book, &mev_store).await;
                 }
             }
             event = swarm.select_next_some() => {
-                handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book, &quote_book);
+                handle_swarm_event(event, &mut swarm, &topic, &attestation_msg, &mut peer_registry, &archiver, &reputation_store, &coordination_book, &quote_book, &mev_store);
             }
             _ = score_refresh_interval.tick() => {
                 refresh_peer_scores(&mut swarm, &reputation_store, &coordination_book, &quote_book);
@@ -204,6 +208,8 @@ struct PendingSwap {
     conditions: reputation::SwapConditions,
     /// If this swap is part of a coordinated proposal.
     proposal_id: Option<String>,
+    /// Max acceptable slippage in basis points for on-chain enforcement.
+    max_slippage_bps: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -219,6 +225,7 @@ async fn handle_input(
     reputation_store: &ReputationStore,
     coordination_book: &CoordinationBook,
     quote_book: &QuoteBook,
+    mev_store: &MevStore,
 ) -> Option<PendingSwap> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
@@ -238,6 +245,7 @@ async fn handle_input(
             println!("    --min-rep <score>   Minimum reputation score (0.0-1.0)");
             println!("    --min-price <val>   Price floor");
             println!("    --max-price <val>   Price ceiling");
+            println!("    --slippage <bps>    Max slippage in basis points (overrides mev-config)");
             println!("  status              - Query V1 on-chain swap counts");
             println!("  status-v2           - Query V2 swap counts + your fee tier");
             println!("  intent <amount> <a2b|b2a> [min] [max] - Broadcast swap intent");
@@ -255,6 +263,8 @@ async fn handle_input(
             println!("  log-status          - Show log buffer count and sidecar URL");
             println!("  who                 - Show your PeerId and EOA");
             println!("  peers               - List all verified peer identities + trust");
+            println!("  mev                 - Show MEV stats (own slippage + peer alerts)");
+            println!("  mev-config <bps>    - Set max slippage tolerance in basis points");
             println!("  help                - Show this message");
             println!("  <text>              - Send chat message to peers");
         }
@@ -289,12 +299,14 @@ async fn handle_input(
 
             // Broadcast intent, then defer execution to the main loop
             // so the swarm can flush the intent to peers first
+            let slippage_bps = mev_store.max_slippage_bps();
             let intent_msg = AgentMessage::SwapIntent {
                 agent: swarm.local_peer_id().to_string(),
                 direction: direction.to_string(),
                 amount: amount_str.to_string(),
                 min_price: None,
                 max_price: None,
+                max_slippage_bps: Some(slippage_bps),
                 timestamp: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
@@ -302,7 +314,7 @@ async fn handle_input(
             };
             publish_message(swarm, intent_topic, &intent_msg);
             reputation_store.record_intent(&swarm.local_peer_id().to_string());
-            println!("[INTENT] Broadcast: {amount_str} {direction}");
+            println!("[INTENT] Broadcast: {amount_str} {direction} (slippage: {slippage_bps} bps)");
 
             return Some(PendingSwap {
                 is_v2,
@@ -312,6 +324,7 @@ async fn handle_input(
                 version: version.to_string(),
                 conditions: reputation::SwapConditions::default(),
                 proposal_id: None,
+                max_slippage_bps: slippage_bps,
             });
         }
         "status" => match swap_client.get_swap_counts().await {
@@ -352,6 +365,7 @@ async fn handle_input(
                         amount: amount.to_string(),
                         min_price: min_price.clone(),
                         max_price: max_price.clone(),
+                        max_slippage_bps: Some(mev_store.max_slippage_bps()),
                         timestamp: std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()
@@ -488,6 +502,7 @@ async fn handle_input(
                 let zero_for_one = tokens[1] == "a2b";
 
                 let mut conditions = reputation::SwapConditions::default();
+                let mut slippage_override: Option<u64> = None;
                 let mut i = 2;
                 while i < tokens.len() {
                     match tokens[i] {
@@ -507,18 +522,24 @@ async fn handle_input(
                             conditions.max_price = tokens.get(i + 1).map(|s| s.to_string());
                             i += 2;
                         }
+                        "--slippage" => {
+                            slippage_override = tokens.get(i + 1).and_then(|s| s.parse().ok());
+                            i += 2;
+                        }
                         _ => {
                             i += 1;
                         }
                     }
                 }
 
+                let slippage_bps = slippage_override.unwrap_or_else(|| mev_store.max_slippage_bps());
                 let intent_msg = AgentMessage::SwapIntent {
                     agent: swarm.local_peer_id().to_string(),
                     direction: direction.to_string(),
                     amount: amount.to_string(),
                     min_price: conditions.min_price.clone(),
                     max_price: conditions.max_price.clone(),
+                    max_slippage_bps: Some(slippage_bps),
                     timestamp: std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()
@@ -537,11 +558,8 @@ async fn handle_input(
                 if let Some(ref p) = conditions.max_price {
                     cond_parts.push(format!("max-price: {p}"));
                 }
-                let cond_str = if cond_parts.is_empty() {
-                    String::new()
-                } else {
-                    format!(" ({})", cond_parts.join(", "))
-                };
+                cond_parts.push(format!("slippage: {slippage_bps} bps"));
+                let cond_str = format!(" ({})", cond_parts.join(", "));
                 println!("[CSWAP] Broadcast conditional intent: {amount} {direction}{cond_str}");
 
                 return Some(PendingSwap {
@@ -552,6 +570,7 @@ async fn handle_input(
                     version: "V1".to_string(),
                     conditions,
                     proposal_id: None,
+                    max_slippage_bps: slippage_bps,
                 });
             } else {
                 println!("Usage: cswap <amount> <a2b|b2a> [--min-rep <score>] [--min-price <val>] [--max-price <val>]");
@@ -674,12 +693,14 @@ async fn handle_input(
 
                         // Execute the desired counter-swap
                         let zero_for_one = proposal.desired_direction.contains("TKNA -> TKNB");
+                        let slippage_bps = mev_store.max_slippage_bps();
                         let intent_msg = AgentMessage::SwapIntent {
                             agent: swarm.local_peer_id().to_string(),
                             direction: proposal.desired_direction.clone(),
                             amount: proposal.desired_amount.clone(),
                             min_price: None,
                             max_price: None,
+                            max_slippage_bps: Some(slippage_bps),
                             timestamp: std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()
@@ -699,6 +720,7 @@ async fn handle_input(
                             version: "V1".to_string(),
                             conditions: reputation::SwapConditions::default(),
                             proposal_id: Some(proposal.proposal_id.clone()),
+                            max_slippage_bps: slippage_bps,
                         });
                     }
                     Some((_, _)) => {
@@ -960,12 +982,14 @@ async fn handle_input(
 
                         // Broadcast intent and trigger swap execution
                         let zero_for_one = request.direction.contains("TKNA -> TKNB");
+                        let slippage_bps = mev_store.max_slippage_bps();
                         let intent_msg = AgentMessage::SwapIntent {
                             agent: swarm.local_peer_id().to_string(),
                             direction: request.direction.clone(),
                             amount: request.amount.clone(),
                             min_price: None,
                             max_price: None,
+                            max_slippage_bps: Some(slippage_bps),
                             timestamp: std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()
@@ -982,6 +1006,7 @@ async fn handle_input(
                             version: "V1".to_string(),
                             conditions: reputation::SwapConditions::default(),
                             proposal_id: None,
+                            max_slippage_bps: slippage_bps,
                         });
                     }
                     None => {
@@ -1038,6 +1063,48 @@ async fn handle_input(
                 }
             }
         }
+        "mev" => {
+            let summary = mev_store.own_summary();
+            println!("=== MEV Stats ===");
+            println!("Config:    max slippage {} bps ({:.2}%)", mev_store.max_slippage_bps(), mev_store.max_slippage_bps() as f64 / 100.0);
+            println!("Own swaps: {}", summary.total_swaps);
+            if summary.total_swaps > 0 {
+                println!("  Avg slippage:   {} bps", summary.avg_slippage_bps);
+                println!("  Worst slippage: {} bps", summary.worst_slippage_bps);
+                println!("  Sandwiches:     {}", summary.sandwich_count);
+            }
+            let peer_stats = mev_store.peer_stats_all();
+            if !peer_stats.is_empty() {
+                println!("Peer alerts ({}):", peer_stats.len());
+                for (pid, stats) in &peer_stats {
+                    let short = &pid[..8.min(pid.len())];
+                    println!(
+                        "  {}... — {} alerts | avg slippage: {} bps | sandwiches: {}",
+                        short, stats.alerts_received, stats.avg_slippage_bps(), stats.sandwich_count
+                    );
+                }
+            } else {
+                println!("No peer MEV alerts received yet.");
+            }
+        }
+        "mev-config" => {
+            if let Some(arg) = parts.get(1) {
+                match arg.parse::<u64>() {
+                    Ok(bps) => {
+                        mev_store.set_max_slippage_bps(bps);
+                        println!("MEV config updated: max slippage = {bps} bps ({:.2}%)", bps as f64 / 100.0);
+                    }
+                    Err(_) => println!("Usage: mev-config <bps>  (e.g. 50 for 0.5%)"),
+                }
+            } else {
+                println!(
+                    "Current max slippage: {} bps ({:.2}%)",
+                    mev_store.max_slippage_bps(),
+                    mev_store.max_slippage_bps() as f64 / 100.0
+                );
+                println!("Usage: mev-config <bps>  (e.g. 50 for 0.5%)");
+            }
+        }
         _ => {
             let msg = AgentMessage::Chat {
                 content: trimmed.to_string(),
@@ -1075,6 +1142,7 @@ async fn execute_pending_swap(
     archiver: &LogArchiver,
     coordination_book: &CoordinationBook,
     reputation_store: &ReputationStore,
+    mev_store: &MevStore,
 ) {
     if sim_mode.is_active() {
         let peer_id_str = swarm.local_peer_id().to_string();
@@ -1115,8 +1183,8 @@ async fn execute_pending_swap(
         }
     } else {
         println!(
-            "Executing {} swap: {} {}...",
-            swap.version, swap.amount_str, swap.direction
+            "Executing {} swap: {} {} (slippage guard: {} bps)...",
+            swap.version, swap.amount_str, swap.direction, swap.max_slippage_bps
         );
 
         let amount = match swap.amount_str.parse::<u64>() {
@@ -1127,14 +1195,26 @@ async fn execute_pending_swap(
             }
         };
 
+        // Compute on-chain slippage floor from configured tolerance
+        let amount_out_min = mev::compute_amount_out_min(amount, swap.max_slippage_bps);
+        println!(
+            "  amountOutMin: {} ({}e-18)",
+            amount_out_min,
+            swap.amount_str
+        );
+
         let result = if swap.is_v2 {
-            swap_client.execute_swap_v2(amount, swap.zero_for_one).await
+            swap_client
+                .execute_swap_v2(amount, swap.zero_for_one, amount_out_min)
+                .await
         } else {
-            swap_client.execute_swap(amount, swap.zero_for_one).await
+            swap_client
+                .execute_swap(amount, swap.zero_for_one, amount_out_min)
+                .await
         };
 
         match result {
-            Ok(tx_hash) => {
+            Ok((tx_hash, actual_out)) => {
                 let msg = AgentMessage::SwapExecuted {
                     agent: swarm.local_peer_id().to_string(),
                     direction: swap.direction.clone(),
@@ -1152,6 +1232,49 @@ async fn execute_pending_swap(
                 ));
                 if !sim_mode.is_local() {
                     println!("  https://sepolia.etherscan.io/tx/{tx_hash}");
+                }
+
+                // Post-execution MEV analysis
+                let realized_slippage_bps =
+                    mev::compute_realized_slippage_bps(amount, actual_out);
+                let sandwich = mev::is_sandwich(amount, actual_out);
+                let timestamp = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+
+                if realized_slippage_bps > 0 {
+                    println!(
+                        "  [MEV] Realized slippage: {} bps{}",
+                        realized_slippage_bps,
+                        if sandwich { " ⚠ SANDWICH DETECTED" } else { "" }
+                    );
+                }
+
+                mev_store.record_event(mev::MevEvent {
+                    direction: swap.direction.clone(),
+                    amount_in: amount,
+                    amount_out_min,
+                    actual_out,
+                    realized_slippage_bps,
+                    sandwich_detected: sandwich,
+                    timestamp,
+                });
+
+                // Broadcast MevAlert if sandwich-level slippage detected
+                if sandwich {
+                    let alert = AgentMessage::MevAlert {
+                        reporter: swarm.local_peer_id().to_string(),
+                        direction: swap.direction.clone(),
+                        amount_in: swap.amount_str.clone(),
+                        amount_out_min: amount_out_min.to_string(),
+                        actual_out: actual_out.to_string(),
+                        realized_slippage_bps,
+                        sandwich_detected: true,
+                        timestamp,
+                    };
+                    publish_message(swarm, topic, &alert);
+                    println!("  [MEV] Alert broadcast to peers.");
                 }
 
                 // Publish SwapFill if part of a coordinated swap
@@ -1184,6 +1307,7 @@ fn handle_swarm_event(
     reputation_store: &ReputationStore,
     coordination_book: &CoordinationBook,
     quote_book: &QuoteBook,
+    mev_store: &MevStore,
 ) {
     match event {
         SwarmEvent::Behaviour(AgentBehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
@@ -1249,6 +1373,7 @@ fn handle_swarm_event(
                         amount,
                         min_price,
                         max_price,
+                        max_slippage_bps,
                         timestamp,
                     } => {
                         let bounds = match (min_price, max_price) {
@@ -1257,12 +1382,15 @@ fn handle_swarm_event(
                             (None, Some(max)) => format!(" max: {max}"),
                             _ => String::new(),
                         };
+                        let slippage_str = max_slippage_bps
+                            .map(|bps| format!(" slippage≤{bps}bps"))
+                            .unwrap_or_default();
                         let secs = timestamp % 60;
                         let mins = (timestamp / 60) % 60;
                         let hours = (timestamp / 3600) % 24;
                         let time_str = format!("{hours:02}:{mins:02}:{secs:02} UTC");
                         println!(
-                            "[INTENT] Agent {agent} intends to swap {amount} ({direction}){bounds} at {time_str}"
+                            "[INTENT] Agent {agent} intends to swap {amount} ({direction}){bounds}{slippage_str} at {time_str}"
                         );
                         reputation_store.record_intent(&agent);
                         if let Ok(pid) = agent.parse::<libp2p::PeerId>() {
@@ -1552,6 +1680,29 @@ fn handle_swarm_event(
                                 },
                             );
                         }
+                    }
+                    AgentMessage::MevAlert {
+                        reporter,
+                        direction,
+                        amount_in,
+                        amount_out_min,
+                        actual_out,
+                        realized_slippage_bps,
+                        sandwich_detected,
+                        timestamp: _,
+                    } => {
+                        let reporter_short = &reporter[..8.min(reporter.len())];
+                        let sandwich_flag = if sandwich_detected { " ⚠ SANDWICH" } else { "" };
+                        println!(
+                            "[MEV-ALERT] {reporter_short} swapped {amount_in} ({direction}): \
+                             out_min={amount_out_min} actual={actual_out} \
+                             slippage={realized_slippage_bps}bps{sandwich_flag}"
+                        );
+                        mev_store.record_peer_alert(
+                            &reporter,
+                            realized_slippage_bps,
+                            sandwich_detected,
+                        );
                     }
                 }
             } else {

--- a/agent/src/mev.rs
+++ b/agent/src/mev.rs
@@ -1,0 +1,165 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use alloy::primitives::U256;
+
+/// Default max slippage: 50 basis points (0.5%).
+pub const DEFAULT_MAX_SLIPPAGE_BPS: u64 = 50;
+
+/// Sandwich detection threshold: 200 bps (2%).
+///
+/// If realized slippage exceeds this after a successful swap, the execution
+/// environment was likely adversarial (sandwich attack or extreme price impact).
+pub const SANDWICH_THRESHOLD_BPS: u64 = 200;
+
+/// Per-agent MEV configuration. Governs slippage enforcement on all outgoing swaps.
+#[derive(Debug, Clone)]
+pub struct MevConfig {
+    /// Maximum acceptable slippage in basis points (100 bps = 1%).
+    /// Enforced on-chain via `amountOutMin`.
+    pub max_slippage_bps: u64,
+}
+
+impl Default for MevConfig {
+    fn default() -> Self {
+        Self {
+            max_slippage_bps: DEFAULT_MAX_SLIPPAGE_BPS,
+        }
+    }
+}
+
+/// Record of a single swap's MEV outcome.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct MevEvent {
+    /// Swap direction label (e.g. "TKNA -> TKNB").
+    pub direction: String,
+    /// Input token amount in wei.
+    pub amount_in: U256,
+    /// Minimum output enforced on-chain (amountOutMin passed to router).
+    pub amount_out_min: U256,
+    /// Actual output received (measured via balance diff).
+    pub actual_out: U256,
+    /// Realized slippage vs expected 1:1 output, in basis points.
+    pub realized_slippage_bps: u64,
+    /// True if `realized_slippage_bps` exceeded `SANDWICH_THRESHOLD_BPS`.
+    pub sandwich_detected: bool,
+    pub timestamp: u64,
+}
+
+/// Aggregated MEV statistics for a remote peer (built from received `MevAlert` messages).
+#[derive(Debug, Clone, Default)]
+pub struct PeerMevStats {
+    /// Total MevAlert messages received from this peer.
+    pub alerts_received: u64,
+    /// How many flagged a sandwich.
+    pub sandwich_count: u64,
+    /// Cumulative realized slippage across all alerts (in bps).
+    pub total_slippage_bps: u64,
+}
+
+impl PeerMevStats {
+    pub fn avg_slippage_bps(&self) -> u64 {
+        if self.alerts_received == 0 {
+            0
+        } else {
+            self.total_slippage_bps / self.alerts_received
+        }
+    }
+}
+
+/// Thread-safe store for own MEV events and remote peer alert history.
+pub struct MevStore {
+    own_events: Arc<Mutex<Vec<MevEvent>>>,
+    peer_stats: Arc<Mutex<HashMap<String, PeerMevStats>>>,
+    config: Arc<Mutex<MevConfig>>,
+}
+
+impl MevStore {
+    pub fn new() -> Self {
+        Self {
+            own_events: Arc::new(Mutex::new(Vec::new())),
+            peer_stats: Arc::new(Mutex::new(HashMap::new())),
+            config: Arc::new(Mutex::new(MevConfig::default())),
+        }
+    }
+
+    pub fn max_slippage_bps(&self) -> u64 {
+        self.config.lock().unwrap().max_slippage_bps
+    }
+
+    pub fn set_max_slippage_bps(&self, bps: u64) {
+        self.config.lock().unwrap().max_slippage_bps = bps;
+    }
+
+    pub fn record_event(&self, event: MevEvent) {
+        self.own_events.lock().unwrap().push(event);
+    }
+
+    pub fn record_peer_alert(&self, peer_id: &str, slippage_bps: u64, sandwich_detected: bool) {
+        let mut stats = self.peer_stats.lock().unwrap();
+        let entry = stats.entry(peer_id.to_string()).or_default();
+        entry.alerts_received += 1;
+        entry.total_slippage_bps += slippage_bps;
+        if sandwich_detected {
+            entry.sandwich_count += 1;
+        }
+    }
+
+    /// Summary of our own swap MEV outcomes.
+    pub fn own_summary(&self) -> MevSummary {
+        let events = self.own_events.lock().unwrap();
+        let total = events.len() as u64;
+        let sandwiches = events.iter().filter(|e| e.sandwich_detected).count() as u64;
+        let total_slip: u64 = events.iter().map(|e| e.realized_slippage_bps).sum();
+        let worst = events.iter().map(|e| e.realized_slippage_bps).max().unwrap_or(0);
+        MevSummary {
+            total_swaps: total,
+            sandwich_count: sandwiches,
+            avg_slippage_bps: if total > 0 { total_slip / total } else { 0 },
+            worst_slippage_bps: worst,
+        }
+    }
+
+    pub fn peer_stats_all(&self) -> HashMap<String, PeerMevStats> {
+        self.peer_stats.lock().unwrap().clone()
+    }
+}
+
+/// Summary of our own MEV outcomes across all swaps.
+#[derive(Debug, Clone)]
+pub struct MevSummary {
+    pub total_swaps: u64,
+    pub sandwich_count: u64,
+    pub avg_slippage_bps: u64,
+    pub worst_slippage_bps: u64,
+}
+
+/// Compute `amountOutMin` for on-chain slippage enforcement.
+///
+/// For a 1:1 pool, `amount_in` ≈ `amount_out` before fees and price impact.
+/// This sets the floor the router must meet or the transaction reverts.
+///
+/// Example: 100 tokens in, 50 bps → amountOutMin = 99.5 tokens (in wei).
+pub fn compute_amount_out_min(amount_in: U256, slippage_bps: u64) -> U256 {
+    let clamped = slippage_bps.min(9_999);
+    let numerator = amount_in * U256::from(10_000u64 - clamped);
+    numerator / U256::from(10_000u64)
+}
+
+/// Compute realized slippage in bps relative to expected 1:1 output.
+///
+/// `expected_out` is `amount_in` for this pool (1:1 price baseline).
+/// Returns 0 if actual_out >= expected_out (no slippage or favorable fill).
+pub fn compute_realized_slippage_bps(expected_out: U256, actual_out: U256) -> u64 {
+    if expected_out.is_zero() || actual_out >= expected_out {
+        return 0;
+    }
+    let shortfall = expected_out - actual_out;
+    (shortfall * U256::from(10_000u64) / expected_out).saturating_to::<u64>()
+}
+
+/// Returns `true` if realized slippage exceeds `SANDWICH_THRESHOLD_BPS`.
+pub fn is_sandwich(expected_out: U256, actual_out: U256) -> bool {
+    compute_realized_slippage_bps(expected_out, actual_out) > SANDWICH_THRESHOLD_BPS
+}

--- a/agent/src/network.rs
+++ b/agent/src/network.rs
@@ -45,6 +45,10 @@ pub enum AgentMessage {
         amount: String,
         min_price: Option<String>,
         max_price: Option<String>,
+        /// Maximum acceptable slippage in basis points (100 bps = 1%).
+        /// Signals to peers how sensitive this agent is to adverse execution.
+        #[serde(default)]
+        max_slippage_bps: Option<u64>,
         timestamp: u64,
     },
     /// Coordinated swap proposal — seeking a counterparty
@@ -92,6 +96,25 @@ pub enum AgentMessage {
         quote_id: String,
         response_id: String,
         acceptor: String,
+    },
+    /// MEV alert — broadcast when a swap's realized slippage exceeds the sandwich threshold.
+    /// Peers use this to build a network-wide picture of execution quality.
+    MevAlert {
+        /// PeerId of the agent reporting the event.
+        reporter: String,
+        /// Swap direction (e.g. "TKNA -> TKNB").
+        direction: String,
+        /// Input amount (human-readable, e.g. "100").
+        amount_in: String,
+        /// amountOutMin enforced on-chain (wei, as decimal string).
+        amount_out_min: String,
+        /// Actual output received (wei, as decimal string).
+        actual_out: String,
+        /// Realized slippage in basis points.
+        realized_slippage_bps: u64,
+        /// True if slippage exceeded the sandwich detection threshold.
+        sandwich_detected: bool,
+        timestamp: u64,
     },
 }
 

--- a/agent/src/tests/mev.rs
+++ b/agent/src/tests/mev.rs
@@ -1,0 +1,268 @@
+use alloy::primitives::U256;
+
+use crate::mev::{
+    compute_amount_out_min, compute_realized_slippage_bps, is_sandwich, MevStore,
+    DEFAULT_MAX_SLIPPAGE_BPS, SANDWICH_THRESHOLD_BPS,
+};
+
+fn wei(tokens: u64) -> U256 {
+    U256::from(tokens) * U256::from(10u64.pow(18))
+}
+
+// ── compute_amount_out_min ──────────────────────────────────────────────────
+
+#[test]
+fn amount_out_min_zero_slippage() {
+    let amount = wei(100);
+    let out_min = compute_amount_out_min(amount, 0);
+    assert_eq!(out_min, amount, "zero slippage => amountOutMin == amountIn");
+}
+
+#[test]
+fn amount_out_min_fifty_bps() {
+    // 100 tokens, 50 bps (0.5%) slippage → floor = 99.5 tokens
+    let amount = wei(100);
+    let out_min = compute_amount_out_min(amount, 50);
+    let expected = wei(100) * U256::from(9950u64) / U256::from(10_000u64);
+    assert_eq!(out_min, expected);
+}
+
+#[test]
+fn amount_out_min_hundred_bps() {
+    // 100 tokens, 100 bps (1%) → floor = 99 tokens
+    let amount = wei(100);
+    let out_min = compute_amount_out_min(amount, 100);
+    let expected = wei(100) * U256::from(9900u64) / U256::from(10_000u64);
+    assert_eq!(out_min, expected);
+}
+
+#[test]
+fn amount_out_min_clamps_at_9999_bps() {
+    // 10000 bps would give 0 — clamped to 9999 so floor > 0
+    let amount = wei(100);
+    let out_min = compute_amount_out_min(amount, 10_000);
+    let clamped = compute_amount_out_min(amount, 9_999);
+    assert_eq!(out_min, clamped, "10000 bps clamps to 9999");
+    assert!(out_min > U256::ZERO);
+}
+
+#[test]
+fn amount_out_min_default_config() {
+    let amount = wei(50);
+    let out_min = compute_amount_out_min(amount, DEFAULT_MAX_SLIPPAGE_BPS);
+    // Should be slightly less than input but close
+    assert!(out_min < amount);
+    assert!(out_min > wei(49)); // 49.75 tokens
+}
+
+// ── compute_realized_slippage_bps ───────────────────────────────────────────
+
+#[test]
+fn slippage_bps_no_slippage() {
+    // actual == expected → 0 slippage
+    let expected = wei(100);
+    assert_eq!(compute_realized_slippage_bps(expected, expected), 0);
+}
+
+#[test]
+fn slippage_bps_better_than_expected() {
+    // actual > expected → 0 (favourable, not reported as slippage)
+    let expected = wei(100);
+    let actual = wei(101);
+    assert_eq!(compute_realized_slippage_bps(expected, actual), 0);
+}
+
+#[test]
+fn slippage_bps_half_percent() {
+    // 100 → 99.5 tokens = 50 bps
+    let expected = wei(100);
+    let actual = wei(100) * U256::from(9950u64) / U256::from(10_000u64);
+    assert_eq!(compute_realized_slippage_bps(expected, actual), 50);
+}
+
+#[test]
+fn slippage_bps_one_percent() {
+    let expected = wei(100);
+    let actual = wei(99);
+    assert_eq!(compute_realized_slippage_bps(expected, actual), 100);
+}
+
+#[test]
+fn slippage_bps_zero_expected_returns_zero() {
+    assert_eq!(compute_realized_slippage_bps(U256::ZERO, wei(50)), 0);
+}
+
+// ── is_sandwich ─────────────────────────────────────────────────────────────
+
+#[test]
+fn is_sandwich_below_threshold() {
+    // 1% slippage < SANDWICH_THRESHOLD_BPS (200) → not a sandwich
+    let expected = wei(100);
+    let actual = wei(99);
+    assert!(!is_sandwich(expected, actual));
+}
+
+#[test]
+fn is_sandwich_at_threshold() {
+    // exactly at threshold (200 bps = 2%) → not a sandwich (threshold is strict >)
+    let expected = U256::from(10_000u64);
+    let actual = U256::from(9_800u64); // exactly 200 bps below
+    assert!(!is_sandwich(expected, actual));
+}
+
+#[test]
+fn is_sandwich_above_threshold() {
+    // 3% slippage > SANDWICH_THRESHOLD_BPS (200) → sandwich
+    let expected = wei(100);
+    let actual = wei(97);
+    assert!(is_sandwich(expected, actual));
+}
+
+#[test]
+fn is_sandwich_extreme_slippage() {
+    let expected = wei(100);
+    let actual = wei(50); // 50% slippage
+    assert!(is_sandwich(expected, actual));
+}
+
+#[test]
+fn sandwich_threshold_constant_is_200() {
+    assert_eq!(SANDWICH_THRESHOLD_BPS, 200);
+}
+
+// ── MevStore ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn mev_store_default_slippage() {
+    let store = MevStore::new();
+    assert_eq!(store.max_slippage_bps(), DEFAULT_MAX_SLIPPAGE_BPS);
+}
+
+#[test]
+fn mev_store_set_slippage() {
+    let store = MevStore::new();
+    store.set_max_slippage_bps(100);
+    assert_eq!(store.max_slippage_bps(), 100);
+}
+
+#[test]
+fn mev_store_own_summary_empty() {
+    let store = MevStore::new();
+    let summary = store.own_summary();
+    assert_eq!(summary.total_swaps, 0);
+    assert_eq!(summary.sandwich_count, 0);
+    assert_eq!(summary.avg_slippage_bps, 0);
+    assert_eq!(summary.worst_slippage_bps, 0);
+}
+
+#[test]
+fn mev_store_record_event_normal() {
+    let store = MevStore::new();
+    store.record_event(crate::mev::MevEvent {
+        direction: "TKNA -> TKNB".into(),
+        amount_in: wei(100),
+        amount_out_min: wei(99),
+        actual_out: wei(99),
+        realized_slippage_bps: 100,
+        sandwich_detected: false,
+        timestamp: 0,
+    });
+    let summary = store.own_summary();
+    assert_eq!(summary.total_swaps, 1);
+    assert_eq!(summary.sandwich_count, 0);
+    assert_eq!(summary.avg_slippage_bps, 100);
+    assert_eq!(summary.worst_slippage_bps, 100);
+}
+
+#[test]
+fn mev_store_record_sandwich_event() {
+    let store = MevStore::new();
+    store.record_event(crate::mev::MevEvent {
+        direction: "TKNB -> TKNA".into(),
+        amount_in: wei(100),
+        amount_out_min: wei(99),
+        actual_out: wei(95),
+        realized_slippage_bps: 500,
+        sandwich_detected: true,
+        timestamp: 1000,
+    });
+    let summary = store.own_summary();
+    assert_eq!(summary.total_swaps, 1);
+    assert_eq!(summary.sandwich_count, 1);
+    assert_eq!(summary.worst_slippage_bps, 500);
+}
+
+#[test]
+fn mev_store_avg_slippage_multiple_events() {
+    let store = MevStore::new();
+    for bps in [100u64, 200, 300] {
+        store.record_event(crate::mev::MevEvent {
+            direction: "TKNA -> TKNB".into(),
+            amount_in: wei(100),
+            amount_out_min: wei(99),
+            actual_out: U256::ZERO,
+            realized_slippage_bps: bps,
+            sandwich_detected: bps > SANDWICH_THRESHOLD_BPS,
+            timestamp: 0,
+        });
+    }
+    let summary = store.own_summary();
+    assert_eq!(summary.total_swaps, 3);
+    assert_eq!(summary.avg_slippage_bps, 200); // (100+200+300)/3
+    assert_eq!(summary.worst_slippage_bps, 300);
+    assert_eq!(summary.sandwich_count, 1); // only 300 > 200
+}
+
+#[test]
+fn mev_store_record_peer_alert() {
+    let store = MevStore::new();
+    store.record_peer_alert("peer1", 250, true);
+    store.record_peer_alert("peer1", 150, false);
+    let stats = store.peer_stats_all();
+    let peer = stats.get("peer1").unwrap();
+    assert_eq!(peer.alerts_received, 2);
+    assert_eq!(peer.sandwich_count, 1);
+    assert_eq!(peer.total_slippage_bps, 400);
+    assert_eq!(peer.avg_slippage_bps(), 200);
+}
+
+#[test]
+fn mev_store_peer_stats_independent() {
+    let store = MevStore::new();
+    store.record_peer_alert("peer1", 100, false);
+    store.record_peer_alert("peer2", 300, true);
+    let stats = store.peer_stats_all();
+    assert_eq!(stats.len(), 2);
+    assert_eq!(stats["peer1"].alerts_received, 1);
+    assert_eq!(stats["peer2"].sandwich_count, 1);
+}
+
+#[test]
+fn mev_store_thread_safety() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let store = Arc::new(MevStore::new());
+    let mut handles = vec![];
+    for i in 0..4 {
+        let s = Arc::clone(&store);
+        handles.push(thread::spawn(move || {
+            s.record_event(crate::mev::MevEvent {
+                direction: "TKNA -> TKNB".into(),
+                amount_in: wei(10),
+                amount_out_min: wei(9),
+                actual_out: wei(9),
+                realized_slippage_bps: i * 50,
+                sandwich_detected: false,
+                timestamp: i as u64,
+            });
+            s.record_peer_alert(&format!("peer{i}"), i * 10, false);
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    let summary = store.own_summary();
+    assert_eq!(summary.total_swaps, 4);
+    assert_eq!(store.peer_stats_all().len(), 4);
+}

--- a/agent/src/tests/mod.rs
+++ b/agent/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod archival;
 mod coordination;
 mod identity;
+mod mev;
 mod network;
 mod quotes;
 mod reputation;

--- a/agent/src/tests/network.rs
+++ b/agent/src/tests/network.rs
@@ -99,6 +99,7 @@ fn swap_intent_roundtrip() {
         amount: "10".into(),
         min_price: Some("0.95".into()),
         max_price: Some("1.05".into()),
+        max_slippage_bps: None,
         timestamp: 1700000000,
     };
     let json = serde_json::to_string(&msg).unwrap();
@@ -111,6 +112,7 @@ fn swap_intent_roundtrip() {
             min_price,
             max_price,
             timestamp,
+            ..
         } => {
             assert_eq!(agent, "peer1");
             assert_eq!(direction, "TKNA -> TKNB");
@@ -131,6 +133,7 @@ fn swap_intent_optional_prices_none() {
         amount: "5".into(),
         min_price: None,
         max_price: None,
+        max_slippage_bps: None,
         timestamp: 1700000001,
     };
     let json = serde_json::to_string(&msg).unwrap();
@@ -156,6 +159,7 @@ fn swap_intent_serialized_json_has_type_tag() {
         amount: "1".into(),
         min_price: None,
         max_price: None,
+        max_slippage_bps: None,
         timestamp: 0,
     })
     .unwrap();
@@ -364,4 +368,103 @@ fn thresholds_are_ordered() {
     let (_, thresholds) = build_peer_score_params();
     assert!(thresholds.gossip_threshold > thresholds.publish_threshold);
     assert!(thresholds.publish_threshold > thresholds.graylist_threshold);
+}
+
+#[test]
+fn swap_intent_with_slippage_roundtrip() {
+    let msg = AgentMessage::SwapIntent {
+        agent: "peer1".into(),
+        direction: "TKNA -> TKNB".into(),
+        amount: "100".into(),
+        min_price: None,
+        max_price: None,
+        max_slippage_bps: Some(50),
+        timestamp: 1_000_000,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::SwapIntent {
+            max_slippage_bps,
+            timestamp,
+            ..
+        } => {
+            assert_eq!(max_slippage_bps, Some(50));
+            assert_eq!(timestamp, 1_000_000);
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn swap_intent_without_slippage_deserializes_as_none() {
+    // Old-format SwapIntent (no max_slippage_bps field) must still deserialize cleanly.
+    let json = r#"{"type":"SwapIntent","agent":"p1","direction":"TKNA -> TKNB","amount":"10","timestamp":0}"#;
+    let decoded: AgentMessage = serde_json::from_str(json).unwrap();
+    match decoded {
+        AgentMessage::SwapIntent {
+            max_slippage_bps, ..
+        } => assert_eq!(max_slippage_bps, None),
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn mev_alert_roundtrip() {
+    let msg = AgentMessage::MevAlert {
+        reporter: "peer1".into(),
+        direction: "TKNA -> TKNB".into(),
+        amount_in: "100".into(),
+        amount_out_min: "99500000000000000000".into(),
+        actual_out: "97000000000000000000".into(),
+        realized_slippage_bps: 301,
+        sandwich_detected: true,
+        timestamp: 9_999,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::MevAlert {
+            reporter,
+            direction,
+            realized_slippage_bps,
+            sandwich_detected,
+            timestamp,
+            ..
+        } => {
+            assert_eq!(reporter, "peer1");
+            assert_eq!(direction, "TKNA -> TKNB");
+            assert_eq!(realized_slippage_bps, 301);
+            assert!(sandwich_detected);
+            assert_eq!(timestamp, 9_999);
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn mev_alert_sandwich_false_roundtrip() {
+    let msg = AgentMessage::MevAlert {
+        reporter: "peer2".into(),
+        direction: "TKNB -> TKNA".into(),
+        amount_in: "50".into(),
+        amount_out_min: "49750000000000000000".into(),
+        actual_out: "49800000000000000000".into(),
+        realized_slippage_bps: 40,
+        sandwich_detected: false,
+        timestamp: 1,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
+    match decoded {
+        AgentMessage::MevAlert {
+            sandwich_detected,
+            realized_slippage_bps,
+            ..
+        } => {
+            assert!(!sandwich_detected);
+            assert_eq!(realized_slippage_bps, 40);
+        }
+        _ => panic!("wrong variant"),
+    }
 }

--- a/agent/src/uniswap.rs
+++ b/agent/src/uniswap.rs
@@ -90,7 +90,17 @@ impl SwapClient {
         }
     }
 
-    pub async fn execute_swap(&self, amount: U256, zero_for_one: bool) -> Result<String> {
+    /// Execute a V1 swap with slippage protection.
+    ///
+    /// `amount_out_min` is enforced on-chain — the router reverts if actual output falls below
+    /// this value. Returns `(tx_hash, actual_out)` where `actual_out` is measured via
+    /// token balance diff, enabling post-execution MEV analysis.
+    pub async fn execute_swap(
+        &self,
+        amount: U256,
+        zero_for_one: bool,
+        amount_out_min: U256,
+    ) -> Result<(String, U256)> {
         let signer: PrivateKeySigner = self.private_key.parse()?;
         let receiver = signer.address();
         let wallet = EthereumWallet::from(signer);
@@ -110,7 +120,12 @@ impl SwapClient {
             approve_receipt.transaction_hash, approve_receipt.transaction_hash
         );
 
-        // Execute swap
+        // Snapshot output token balance before swap to measure actual output
+        let token_out_addr = if zero_for_one { TKNB } else { TKNA };
+        let token_out = IERC20::new(token_out_addr, &provider);
+        let balance_before = token_out.balanceOf(receiver).call().await?._0;
+
+        // Execute swap with on-chain slippage enforcement
         let router = ISwapRouter::new(SWAP_ROUTER, &provider);
         let deadline = U256::from(
             std::time::SystemTime::now()
@@ -121,7 +136,7 @@ impl SwapClient {
 
         let swap_call = router.swapExactTokensForTokens(
             amount,
-            U256::ZERO,
+            amount_out_min,
             zero_for_one,
             Self::pool_key(),
             vec![].into(),
@@ -133,7 +148,11 @@ impl SwapClient {
         let tx_hash = format!("{:#x}", receipt.transaction_hash);
         println!("  Swap executed: tx {tx_hash}");
 
-        Ok(tx_hash)
+        // Measure actual output via balance diff
+        let balance_after = token_out.balanceOf(receiver).call().await?._0;
+        let actual_out = balance_after.saturating_sub(balance_before);
+
+        Ok((tx_hash, actual_out))
     }
 
     /// V2 pool key: same tokens, but uses DYNAMIC_FEE_FLAG so the hook can override
@@ -148,10 +167,17 @@ impl SwapClient {
         }
     }
 
-    /// Execute a swap on the V2 pool.
+    /// Execute a swap on the V2 pool with slippage protection.
+    ///
     /// Unlike V1, this ABI-encodes the agent's EOA address into hookData so the
     /// AgentCounterV2 hook can track the real agent (not the router address).
-    pub async fn execute_swap_v2(&self, amount: U256, zero_for_one: bool) -> Result<String> {
+    /// Returns `(tx_hash, actual_out)` for post-execution MEV analysis.
+    pub async fn execute_swap_v2(
+        &self,
+        amount: U256,
+        zero_for_one: bool,
+        amount_out_min: U256,
+    ) -> Result<(String, U256)> {
         let signer: PrivateKeySigner = self.private_key.parse()?;
         let receiver = signer.address();
         let wallet = EthereumWallet::from(signer);
@@ -171,6 +197,11 @@ impl SwapClient {
             approve_receipt.transaction_hash, approve_receipt.transaction_hash
         );
 
+        // Snapshot output token balance before swap
+        let token_out_addr = if zero_for_one { TKNB } else { TKNA };
+        let token_out = IERC20::new(token_out_addr, &provider);
+        let balance_before = token_out.balanceOf(receiver).call().await?._0;
+
         // Encode agent EOA as hookData for V2 agent tracking
         let hook_data: Bytes = receiver.abi_encode().into();
 
@@ -184,7 +215,7 @@ impl SwapClient {
 
         let swap_call = router.swapExactTokensForTokens(
             amount,
-            U256::ZERO,
+            amount_out_min,
             zero_for_one,
             Self::pool_key_v2(),
             hook_data,
@@ -196,7 +227,11 @@ impl SwapClient {
         let tx_hash = format!("{:#x}", receipt.transaction_hash);
         println!("  Swap executed (V2): tx {tx_hash}");
 
-        Ok(tx_hash)
+        // Measure actual output via balance diff
+        let balance_after = token_out.balanceOf(receiver).call().await?._0;
+        let actual_out = balance_after.saturating_sub(balance_before);
+
+        Ok((tx_hash, actual_out))
     }
 
     /// Query V2 hook for swap counts and the agent's current fee tier.


### PR DESCRIPTION
## Summary

- **Fix zero slippage bug**: `amountOutMin` was hardcoded to `U256::ZERO` — all swaps now enforce on-chain slippage protection via a configurable basis-points tolerance
- **New `mev.rs` module**: `MevStore`, slippage math helpers (`compute_amount_out_min`, `compute_realized_slippage_bps`, `is_sandwich`), per-swap event recording, and peer alert aggregation
- **`MevAlert` gossipsub message**: agents broadcast execution quality reports when realized slippage exceeds the sandwich threshold (200 bps), building a network-wide MEV knowledge base
- **`max_slippage_bps` in `SwapIntent`**: peers can now see each agent's slippage tolerance before coordinating; backward-compatible via `#[serde(default)]`
- **Post-execution analysis**: after every live swap, realized slippage is computed via token balance diff and sandwich detection runs automatically
- **CLI**: `mev` (own stats + peer alerts), `mev-config <bps>` (set tolerance), `--slippage <bps>` per-swap override on `cswap`

## Test plan

- [x] `cargo test` — 170 tests pass (28 new: 24 mev module, 4 network roundtrips)
- [x] `cargo clippy` — clean, no warnings
- [x] Sim mode: `swap 10` prints slippage guard bps in intent broadcast
- [x] `mev-config 100` updates tolerance; `mev` shows updated config
- [x] `cswap 10 a2b --slippage 25` uses per-swap override
- [x] Old `SwapIntent` JSON (no `max_slippage_bps`) deserializes cleanly as `None`

## Summary by Sourcery

Introduce MEV-aware swap coordination with on-chain slippage protection and post-trade analysis, plus gossip-based MEV alerting between agents.

New Features:
- Add MEV configuration and tracking module to manage slippage tolerance and record per-swap MEV outcomes.
- Extend swap intents and network protocol with optional per-intent max slippage field and a new MevAlert message type for broadcasting bad execution events.
- Add CLI commands to inspect MEV stats, configure global slippage tolerance, and override slippage per swap.

Bug Fixes:
- Enforce non-zero slippage protection on swaps by computing and passing amountOutMin instead of hardcoding it to zero.

Enhancements:
- Update swap execution to measure actual output via token balance differences and compute realized slippage and potential sandwich attacks after each trade.
- Surface peer slippage tolerance and MEV alerts in console output to improve operator visibility into execution quality.
- Extend Uniswap V1/V2 client interfaces to support slippage-guarded swaps and return execution details for MEV analysis.

Tests:
- Add comprehensive unit tests for MEV math, configuration, storage, peer alert aggregation, and new message types, including backward-compatible SwapIntent deserialization.